### PR TITLE
Scheduled checks jq tags fix

### DIFF
--- a/.github/workflows/config-schedule-1-ci.yml
+++ b/.github/workflows/config-schedule-1-ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Get all released configs
         id: get-released-config
-        run: echo "tags=$(jq --compact-output --raw-output '.scheduled | del(.default) | keys[]' config/ci.json)" >> $GITHUB_OUTPUT
+        run: echo "tags=$(jq --compact-output --raw-output '.scheduled | del(.default) | keys' config/ci.json)" >> $GITHUB_OUTPUT
 
   repro-ci:
     # We use this reusable workflow with a matrix strategy rather than calling repro-ci.yml, as


### PR DESCRIPTION
Fix jq command in `.github/workflows/config-schedule-1-ci.yml` so output of tags to run scheduled checks on is an array

Failing scheduled check run in access-om2-configs repository: https://github.com/ACCESS-NRI/access-om2-configs/actions/runs/9576132337/job/26402116349