### PR TITLE
Update QA executable paths tests

### DIFF
--- a/src/model_config_tests/conftest.py
+++ b/src/model_config_tests/conftest.py
@@ -118,7 +118,11 @@ def pytest_configure(config):
         "markers", "config: mark as configuration tests in quick QA CI checks"
     )
     config.addinivalue_line(
-        "markers", "access_om2: mark as access-om2 specific tests in quick QA CI checks"
+        "markers", "access_om2: mark as ACCESS-OM2 specific tests in quick QA CI checks"
+    )
+    config.addinivalue_line(
+        "markers",
+        "access_esm1p5: mark as ACCESS-ESM1.5 specific tests in quick QA CI checks",
     )
     config.addinivalue_line(
         "markers", "access_om3: mark as access-om3 specific tests in quick QA CI checks"

--- a/src/model_config_tests/test_access_esm1p5_config.py
+++ b/src/model_config_tests/test_access_esm1p5_config.py
@@ -1,0 +1,29 @@
+# Copyright 2024 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ACCESS-ESM1.5 specific configuration tests"""
+
+import pytest
+
+from model_config_tests.test_config import check_manifest_exes_in_spack_location
+
+# Name of module on NCI
+ACCESS_ESM1P5_MODULE_NAME = "access-esm1p5"
+
+# Name of Model Repository - used for retrieving spack location files for released versions
+ACCESS_ESM1P5_REPOSITORY_NAME = "ACCESS-ESM1.5"
+
+
+@pytest.mark.access_esm1p5
+class TestAccessEsm1p5:
+    """ACCESS-ESM1.5 Specific configuration and metadata tests"""
+
+    def test_access_esm1p5_manifest_exe_in_release_spack_location(
+        self, config, control_path
+    ):
+        check_manifest_exes_in_spack_location(
+            model_module_name=ACCESS_ESM1P5_MODULE_NAME,
+            model_repo_name=ACCESS_ESM1P5_REPOSITORY_NAME,
+            control_path=control_path,
+            config=config,
+        )

--- a/src/model_config_tests/test_access_om2_config.py
+++ b/src/model_config_tests/test_access_om2_config.py
@@ -195,7 +195,7 @@ class TestAccessOM2:
             and metadata["nominal_resolution"] == expected
         ), f"Expected nominal_resolution field set to: {expected}"
 
-    def test_exe_in_manifest_equals_path_in_release_spack_location(
+    def test_access_om2_manifest_exe_in_release_spack_location(
         self, config, branch, control_path
     ):
         # Infer module and repository name from branch - as different for the BGC configuration

--- a/src/model_config_tests/test_access_om2_config.py
+++ b/src/model_config_tests/test_access_om2_config.py
@@ -9,6 +9,7 @@ import warnings
 import f90nml
 import pytest
 
+from model_config_tests.test_config import check_manifest_exes_in_spack_location
 from model_config_tests.util import get_git_branch_name
 
 # Mutually exclusive topic keywords
@@ -31,9 +32,17 @@ TOPIC_KEYWORDS = {
 # https://github.com/WCRP-CMIP/CMIP6_CVs/blob/main/CMIP6_nominal_resolution.json
 NOMINAL_RESOLUTION = {"025deg": "25 km", "01deg": "10 km", "1deg": "100 km"}
 
+# Name of modules on NCI
+ACCESS_OM2_MODULE_NAME = "access-om2"
+ACCESS_OM2_BGC_MODULE_NAME = "access-om2-bgc"
+
+# Name of Model Repositories - used for retrieving spack location files for released versions
+ACCESS_OM2_REPOSITORY_NAME = "ACCESS-OM2"
+ACCESS_OM2_BGC_REPOSITORY_NAME = "ACCESS-OM2-BGC"
+
 
 class AccessOM2Branch:
-    """Use the naming patterns of the branch name to infer informatiom of
+    """Use the naming patterns of the branch name to infer information of
     the ACCESS-OM2 config"""
 
     def __init__(self, branch_name):
@@ -42,6 +51,14 @@ class AccessOM2Branch:
 
         self.is_high_resolution = self.resolution in ["025deg", "01deg"]
         self.is_bgc = "bgc" in branch_name
+
+        # Set expected module and model repository names
+        if self.is_bgc:
+            self.module_name = ACCESS_OM2_BGC_MODULE_NAME
+            self.model_repository_name = ACCESS_OM2_BGC_REPOSITORY_NAME
+        else:
+            self.module_name = ACCESS_OM2_MODULE_NAME
+            self.model_repository_name = ACCESS_OM2_REPOSITORY_NAME
 
     def set_resolution(self):
         # Resolutions are ordered, so the start of the list are matched first
@@ -68,7 +85,7 @@ def branch(control_path, target_branch):
             branch_name is not None
         ), f"Failed getting git branch name of control path: {control_path}"
         warnings.warn(
-            "Target branch is not specifed, defaulting to current git branch: "
+            "Target branch is not specified, defaulting to current git branch: "
             f"{branch_name}. As some ACCESS-OM2 tests infer information, "
             "such as resolution, from the target branch name, some tests may "
             "not be run. To set use --target-branch flag in pytest call"
@@ -177,3 +194,14 @@ class TestAccessOM2:
             "nominal_resolution" in metadata
             and metadata["nominal_resolution"] == expected
         ), f"Expected nominal_resolution field set to: {expected}"
+
+    def test_exe_in_manifest_equals_path_in_release_spack_location(
+        self, config, branch, control_path
+    ):
+        # Infer module and repository name from branch - as different for the BGC configuration
+        check_manifest_exes_in_spack_location(
+            model_module_name=branch.module_name,
+            model_repo_name=branch.model_repository_name,
+            control_path=control_path,
+            config=config,
+        )

--- a/src/model_config_tests/test_config.py
+++ b/src/model_config_tests/test_config.py
@@ -187,7 +187,7 @@ class TestConfig:
         )
 
 
-def exe_manifest_fullpaths(control_path: Path):
+def read_exe_manifest_fullpaths(control_path: Path):
     """Return the full paths to the executables in the executable manifest file"""
     manifest_path = control_path / "manifests" / "exe.yaml"
     with open(manifest_path) as f:
@@ -196,8 +196,8 @@ def exe_manifest_fullpaths(control_path: Path):
     return exe_fullpaths
 
 
-def configured_model_exes(config: dict[str, Any]):
-    """Return the exe values of the model and submodel defined in config.yaml"""
+def read_config_model_exes(config: dict[str, Any]):
+    """Return the exe values of the model and sub-model defined in config.yaml"""
     exes = []
     if "exe" in config:
         exes.append(config["exe"])
@@ -220,7 +220,7 @@ def check_manifest_exes_in_spack_location(
     Parameters
     ----------
     model_module_name: str
-        Expected module name in the config file. This is used to find the version of the model
+        Expected module name in the config.yaml file. This is used to find the version of the model
     model_repo_name: str
         Name of the ACCESS-NRI model repository. This is used to retrieve released spack.location
     control_path: Path
@@ -260,10 +260,10 @@ def check_manifest_exes_in_spack_location(
     spack_location = response.content
 
     # Read exe full paths in the manifests
-    exe_paths = exe_manifest_fullpaths(control_path)
+    exe_paths = read_exe_manifest_fullpaths(control_path)
 
     # Read exe values from the configuration file
-    config_exes = configured_model_exes(config)
+    config_exes = read_config_model_exes(config)
 
     for exe_path in exe_paths:
         install_path, exe_name = exe_path.split("/bin/")

--- a/src/model_config_tests/test_config.py
+++ b/src/model_config_tests/test_config.py
@@ -186,6 +186,17 @@ class TestConfig:
             f"LICENSE file should be equal to {LICENSE} found here: " + LICENSE_URL
         )
 
+    def test_model_module_path_is_defined(self, config):
+        """Check model module path is added to modules in config"""
+        module_paths = config.get("modules", {}).get("use", {})
+        assert RELEASE_MODULE_LOCATION in module_paths, (
+            "Expected model module path is added to module config. E.g.\n"
+            "  modules:\n"
+            "   use:\n"
+            f"    - {RELEASE_MODULE_LOCATION}\n"
+            "This path is used to find model module files"
+        )
+
 
 def read_exe_manifest_fullpaths(control_path: Path):
     """Return the full paths to the executables in the executable manifest file"""

--- a/tests/resources/access-om2/configurations/README.md
+++ b/tests/resources/access-om2/configurations/README.md
@@ -1,0 +1,6 @@
+# Example test configuration 
+
+This contains some files of configuration from the [ACCESS-NRI/access-om2-configs](https://github.com/ACCESS-NRI/access-om2-configs) repository. The configurations contain only the files
+checked with QA checks, so they are incomplete configurations.
+
+There's a low vs high degree, and a BGC vs non-BGC to cover most of the different ACCESS-OM2 configuration specific QA tests.

--- a/tests/resources/access-om2/configurations/dev-025deg_jra55_iaf_bgc/LICENSE
+++ b/tests/resources/access-om2/configurations/dev-025deg_jra55_iaf_bgc/LICENSE
@@ -1,0 +1,396 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/tests/resources/access-om2/configurations/dev-025deg_jra55_iaf_bgc/accessom2.nml
+++ b/tests/resources/access-om2/configurations/dev-025deg_jra55_iaf_bgc/accessom2.nml
@@ -1,0 +1,21 @@
+&accessom2_nml
+    log_level = 'DEBUG'
+
+    ! ice_ocean_timestep defines the MOM baroclinic timestep, CICE thermodynamic timestep
+    ! and MOM-CICE coupling interval, in seconds.
+    ! ice_ocean_timestep is normally a factor of the JRA55-do forcing period of 3hr = 10800s,
+    ! e.g. one of 100, 108, 120, 135, 144, 150, 180, 200, 216, 225, 240, 270, 300, 360, 400, 432,
+    ! 450, 540, 600, 675, 720, 900, 1080, 1200, 1350, 1800, 2160, 2700, 3600 or 5400 seconds.
+    ! The default timestep is 1350s, which should be stable for an initial spinup from rest.
+    ! After the first year or two of equilibration you could try 1800s.
+    ice_ocean_timestep = 1350
+&end
+
+&date_manager_nml
+    forcing_start_date = '1958-01-01T00:00:00'
+    forcing_end_date = '2019-01-01T00:00:00'
+
+    ! Runtime for a single segment/job/submit, format is years, months, seconds,
+    ! two of which must be zero.
+    restart_period = 1, 0, 0
+&end

--- a/tests/resources/access-om2/configurations/dev-025deg_jra55_iaf_bgc/config.yaml
+++ b/tests/resources/access-om2/configurations/dev-025deg_jra55_iaf_bgc/config.yaml
@@ -1,0 +1,120 @@
+# PBS configuration
+
+# If submitting to a different project to your default, uncomment line below
+# and replace PROJECT_CODE with appropriate code. This may require setting shortpath
+# project: PROJECT_CODE
+
+# Force payu to always find, and save, files in this scratch project directory
+# shortpath: /scratch/PROJECT_CODE
+
+queue: normal
+walltime: 3:30:00
+jobname: 025deg_jra55_iaf
+
+# Sync options for automatically copying data from ephemeral scratch space to
+# longer term storage
+sync:
+    enable: False # set path below and change to true
+    path: null # Set to location on /g/data or a remote server and path (rsync syntax)
+
+# Model configuration
+name: common
+model: access-om2
+input:
+  - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.025deg/2023.05.15/rmp_jra55_cice_patch.nc
+  - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.025deg/2023.05.15/rmp_jra55_cice_1st_conserve.nc
+  - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.025deg/2023.05.15/rmp_jra55_cice_2nd_conserve.nc
+submodels:
+    - name: atmosphere
+      model: yatm
+      exe: yatm.exe
+      input:
+            - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.025deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc
+            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429
+            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429
+            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429
+            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429
+            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429
+            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429
+            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429
+            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429
+            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429
+            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429
+            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429
+      ncpus: 1
+
+    - name: ocean
+      model: mom
+      exe: fms_ACCESS-OM-BGC.x
+      input:
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/mosaic/global.025deg/2020.05.30/grid_spec.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/mosaic/global.025deg/2020.05.30/ocean_hgrid.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/mosaic/global.025deg/2020.05.30/ocean_mosaic.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/bathymetry/global.025deg/2023.05.15/topog.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/bathymetry/global.025deg/2023.05.15/ocean_mask.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/vertical/global.025deg/2020.11.02/ocean_vgrid.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/processor_masks/global.025deg/1456.48x40/2023.05.15/ocean_mask_table
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/chlorophyll/global.025deg/2020.05.30/chl.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/initial_conditions/global.025deg/2020.10.22/ocean_temp_salt.res.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/tides/global.025deg/2020.05.30/tideamp.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/tides/global.025deg/2020.05.30/roughness_amp.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/tides/global.025deg/2020.05.30/roughness_cdbot.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/surface_salt_restoring/global.025deg/2020.05.30/salt_sfc_restore.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/biogeochemistry/global.025deg/2022.02.24/bgc_param.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/biogeochemistry/global.025deg/2022.02.24/co2_iaf.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/biogeochemistry/global.025deg/2022.02.24/csiro_bgc.res.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/biogeochemistry/global.025deg/2022.02.24/csiro_bgc_sediment.res.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ocean/biogeochemistry/global.025deg/2022.02.24/dust.nc
+      ncpus: 1456
+
+
+    - name: ice
+      model: cice5
+      exe: cice_auscom_1440x1080_48x40_480p.exe
+      input:
+        - /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.025deg/2024.04.17/grid.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.025deg/2024.04.17/kmt.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ice/initial_conditions_biogeochemistry/global.025deg/2022.02.24/i2o.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ice/initial_conditions_biogeochemistry/global.025deg/2022.02.24/o2i.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ice/initial_conditions/global.025deg/2020.05.30/u_star.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ice/initial_conditions/global.025deg/2020.05.30/monthly_sstsss.nc
+      ncpus: 361
+
+# Collation
+collate:
+  restart: true
+  mpi: true
+  walltime: 1:00:00
+  mem: 30GB
+  ncpus: 4
+  queue: normal
+  exe: /g/data/vk83/apps/mppnccombine-fast/0.2/bin/mppnccombine-fast
+
+# Modules
+modules:
+  use:
+    - /g/data/vk83/modules/access-models
+  load:
+    - access-om2-bgc/2024.03.0
+
+# Misc
+runlog: true
+stacksize: unlimited
+restart_freq: 5YS
+mpirun: --mca io ompio --mca io_ompio_num_aggregators 1
+qsub_flags: -W umask=027
+env:
+    UCX_LOG_LEVEL: 'error'
+
+manifest:
+  reproduce:
+    exe: True
+
+# set number of cores per node (28 for normalbw, 48 for normal on gadi)
+platform:
+    nodesize: 48
+# sweep and resubmit on specific errors - see https://github.com/payu-org/payu/issues/241#issuecomment-610739771
+userscripts:
+    error: tools/resub.sh
+    run: rm -f resubmit.count
+    sync: /g/data/vk83/apps/om2-scripts/concatenate_ice/concat_ice_daily.sh

--- a/tests/resources/access-om2/configurations/dev-025deg_jra55_iaf_bgc/manifests/exe.yaml
+++ b/tests/resources/access-om2/configurations/dev-025deg_jra55_iaf_bgc/manifests/exe.yaml
@@ -1,0 +1,18 @@
+format: yamanifest
+version: 1.0
+---
+work/atmosphere/yatm.exe:
+  fullpath: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/libaccessom2-git.2023.10.26=2023.10.26-ltfg7jcn6t4cefotvj3kjnyu5nru26xo/bin/yatm.exe
+  hashes:
+    binhash: 4e8b4ef76e971c4af3b26cfac632e160
+    md5: 5baa1d417fe6708fc30cbeaa57d82f96
+work/ice/cice_auscom_1440x1080_48x40_480p.exe:
+  fullpath: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/cice5-git.2023.10.19=2023.10.19-v3zncpqjj2gyseudbwiudolcjq3k3leo/bin/cice_auscom_1440x1080_48x40_480p.exe
+  hashes:
+    binhash: 22813654d4a52914003c563fa083e245
+    md5: 38bbb933238af1adc63c6d7eb0b6f7d1
+work/ocean/fms_ACCESS-OM-BGC.x:
+  fullpath: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/mom5-git.2023.11.09=2023.11.09-64l5azdtcoxhrgb5ynn2vued5lmjvn33/bin/fms_ACCESS-OM-BGC.x
+  hashes:
+    binhash: 45352e33876da49ca042014a9f6686e5
+    md5: a909552e85690be692ad3ec94016181b

--- a/tests/resources/access-om2/configurations/dev-025deg_jra55_iaf_bgc/metadata.yaml
+++ b/tests/resources/access-om2/configurations/dev-025deg_jra55_iaf_bgc/metadata.yaml
@@ -1,0 +1,38 @@
+contact: Add your name here
+email: Add your email address here
+created: Add the date you started the experiment here (YYYY-MM-DD)
+description: |-
+  0.25 degree ACCESS-OM2 global model configuration under interannual forcing.
+  The configuration is based on that described in Kiss et al. (2020),
+  https://doi.org/10.5194/gmd-13-401-2020, but with many improvements and
+  coupled biogeochemistry in the ocean and sea ice.
+  Initial conditions are WOA13v2 potential temperature and practical salinity
+  and BGC tracers as in https://github.com/COSIMA/input_om2-bgc/tree/6aee4a4.
+  Run with JRA55-do v1.4.0 interannually-varying forcing with all solid runoff
+  converted to liquid runoff with no heat transfer.
+  Spin up starts 1 Jan 1958 and runs to 1 Jan 2019.
+notes: |-
+  COSIMA request that users of this or other ACCESS-OM2 model code or output data:
+  (a) consider citing Kiss et al. (2020) [http://doi.org/10.5194/gmd-13-401-2020]
+  (b) include an acknowledgement such as the following:
+  "The authors thank the Consortium for Ocean-Sea Ice Modelling in Australia (COSIMA; http://www.cosima.org.au)
+  for making the ACCESS-OM2 suite of models available at https://github.com/COSIMA/access-om2.
+  Model runs were undertaken with the assistance of resources from the National Computational Infrastructure (NCI),
+  which is supported by the Australian Government."
+  (c) let COSIMA know of any publications which use these models or data so they can add them to their list:
+  https://scholar.google.com/citations?hl=en&user=inVqu_4AAAAJ
+keywords:
+- JRA55
+- access-om2-025
+- interannual
+- global
+realm:
+- ocean
+- seaIce
+- ocnBgchem
+nominal_resolution: 25 km
+reference: https://doi.org/10.5194/gmd-13-401-2020
+license: CC-BY-4.0
+model: ACCESS-OM2
+version: '2.0'
+url: https://github.com/ACCESS-NRI/access-om2-configs.git

--- a/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/LICENSE
+++ b/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/LICENSE
@@ -1,0 +1,396 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/README.md
+++ b/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/README.md
@@ -1,0 +1,5 @@
+# Example test configuration 
+
+This contains some files of an release-1deg_jra55_ryf configuration 
+from ACCESS-NRI/access-om2-configs] repository. This contains only the files
+checked with QA checks

--- a/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/README.md
+++ b/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/README.md
@@ -1,5 +1,0 @@
-# Example test configuration 
-
-This contains some files of an release-1deg_jra55_ryf configuration 
-from ACCESS-NRI/access-om2-configs] repository. This contains only the files
-checked with QA checks

--- a/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/accessom2.nml
+++ b/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/accessom2.nml
@@ -1,0 +1,20 @@
+&accessom2_nml
+    log_level = 'DEBUG'
+
+    ! ice_ocean_timestep defines the MOM baroclinic timestep, CICE thermodynamic timestep
+    ! and MOM-CICE coupling interval, in seconds.
+    ! ice_ocean_timestep is normally a factor of the JRA55-do forcing period of 3hr = 10800s,
+    ! e.g. one of 100, 108, 120, 135, 144, 150, 180, 200, 216, 225, 240, 270, 300, 360, 400, 432,
+    ! 450, 540, 600, 675, 720, 900, 1080, 1200, 1350, 1800, 2160, 2700, 3600 or 5400 seconds.
+    ! The model is usually stable with a 5400s timestep, including in the initial spinup from rest.
+    ice_ocean_timestep = 5400
+&end
+
+&date_manager_nml
+    forcing_start_date = '1900-01-01T00:00:00'
+    forcing_end_date = '1901-01-01T00:00:00'
+
+    ! Runtime for a single segment/job/submit, format is years, months, seconds,
+    ! two of which must be zero.
+    restart_period = 5, 0, 0
+&end

--- a/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/config.yaml
+++ b/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/config.yaml
@@ -1,0 +1,108 @@
+# PBS configuration
+
+# If submitting to a different project to your default, uncomment line below
+# and replace PROJECT_CODE with appropriate code. This may require setting shortpath
+# project: PROJECT_CODE
+
+# Force payu to always find, and save, files in this scratch project directory
+# shortpath: /scratch/PROJECT_CODE
+
+queue: normal
+walltime: 3:00:00
+jobname: 1deg_jra55_ryf
+mem: 1000GB
+
+# Sync options for automatically copying data from ephemeral scratch space to
+# longer term storage
+sync:
+    enable: False # set path below and change to true
+    path: null # Set to location on /g/data or a remote server and path (rsync syntax)
+
+# Model configuration
+name: common
+model: access-om2
+input:
+  - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_conserve2nd.nc
+  - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_patch.nc
+  - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jra55_cice_1st_conserve.nc
+  - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jra55_cice_2nd_conserve.nc
+  - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jra55_cice_patch.nc
+submodels:
+    - name: atmosphere
+      model: yatm
+      exe: yatm.exe
+      input:
+            - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc
+            - /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data
+      ncpus: 1
+
+    - name: ocean
+      model: mom
+      exe: fms_ACCESS-OM.x
+      input:
+          - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/mosaic/global.1deg/2020.05.30/grid_spec.nc
+          - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/mosaic/global.1deg/2020.05.30/ocean_hgrid.nc
+          - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/mosaic/global.1deg/2020.05.30/ocean_mosaic.nc
+          - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/bathymetry/global.1deg/2020.10.22/topog.nc
+          - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/bathymetry/global.1deg/2020.10.22/ocean_mask.nc
+          - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/vertical/global.1deg/2020.10.22/ocean_vgrid.nc
+          - /g/data/vk83/experiments/inputs/access-om2/ocean/processor_masks/global.1deg/216.16x15/2020.05.30/ocean_mask_table
+          - /g/data/vk83/experiments/inputs/access-om2/ocean/chlorophyll/global.1deg/2020.05.30/chl.nc
+          - /g/data/vk83/experiments/inputs/access-om2/ocean/initial_conditions/global.1deg/2020.10.22/ocean_temp_salt.res.nc
+          - /g/data/vk83/experiments/inputs/access-om2/ocean/tides/global.1deg/2020.05.30/tideamp.nc
+          - /g/data/vk83/experiments/inputs/access-om2/ocean/tides/global.1deg/2020.05.30/roughness_amp.nc
+          - /g/data/vk83/experiments/inputs/access-om2/ocean/tides/global.1deg/2020.05.30/roughness_cdbot.nc
+          - /g/data/vk83/experiments/inputs/access-om2/ocean/surface_salt_restoring/global.1deg/2020.05.30/salt_sfc_restore.nc
+      ncpus: 216
+
+    - name: ice
+      model: cice5
+      exe: cice_auscom_360x300_24x1_24p.exe
+      input:
+        - /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.1deg/2020.05.30/grid.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.1deg/2020.10.22/kmt.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ice/initial_conditions/global.1deg/2020.05.30/i2o.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ice/initial_conditions/global.1deg/2020.05.30/o2i.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ice/initial_conditions/global.1deg/2020.05.30/u_star.nc
+        - /g/data/vk83/experiments/inputs/access-om2/ice/initial_conditions/global.1deg/2020.05.30/monthly_sstsss.nc
+      ncpus: 24
+
+# Collation
+collate:
+  restart: true
+  walltime: 1:00:00
+  mem: 30GB
+  ncpus: 4
+  queue: normal
+  exe: mppnccombine.spack
+
+# Modules
+modules:
+  use:
+    - /g/data/vk83/modules/access-models
+  load:
+    # Exe paths are found on paths added by this model module
+    - access-om2/2024.03.0
+
+# Misc
+runlog: true
+stacksize: unlimited
+restart_freq: 5YS
+mpirun: --mca io ompio --mca io_ompio_num_aggregators 1
+qsub_flags: -W umask=027
+env:
+    UCX_LOG_LEVEL: 'error'
+
+manifest:
+  reproduce:
+    exe: True
+
+# set number of cores per node (28 for normalbw, 48 for normal on gadi)
+platform:
+    nodesize: 48
+
+# sweep and resubmit on specific errors - see https://github.com/payu-org/payu/issues/241#issuecomment-610739771
+userscripts:
+    error: tools/resub.sh
+    run: rm -f resubmit.count
+    sync: /g/data/vk83/apps/om2-scripts/concatenate_ice/concat_ice_daily.sh

--- a/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/manifests/exe.yaml
+++ b/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/manifests/exe.yaml
@@ -1,0 +1,18 @@
+format: yamanifest
+version: 1.0
+---
+work/atmosphere/yatm.exe:
+  fullpath: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/libaccessom2-git.2023.10.26=2023.10.26-ltfg7jcn6t4cefotvj3kjnyu5nru26xo/bin/yatm.exe
+  hashes:
+    binhash: 4e8b4ef76e971c4af3b26cfac632e160
+    md5: 5baa1d417fe6708fc30cbeaa57d82f96
+work/ice/cice_auscom_360x300_24x1_24p.exe:
+  fullpath: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/cice5-git.2023.10.19=2023.10.19-v3zncpqjj2gyseudbwiudolcjq3k3leo/bin/cice_auscom_360x300_24x1_24p.exe
+  hashes:
+    binhash: 3a65f67d21152e77034da28c22a94c66
+    md5: 37866455b057c85c3ea50c0ef0ea840b
+work/ocean/fms_ACCESS-OM.x:
+  fullpath: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/mom5-git.2023.11.09=2023.11.09-qji4nlmr6utrribaiyhewe4je6mifguz/bin/fms_ACCESS-OM.x
+  hashes:
+    binhash: 92ce1ff1a38f44f92ceafd67e8e7142c
+    md5: a3f10baeadb88e813b4a8121f61a6226

--- a/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/metadata.yaml
+++ b/tests/resources/access-om2/configurations/release-1deg_jra55_ryf/metadata.yaml
@@ -1,0 +1,28 @@
+contact: Add your name here
+email: Add your email address here
+created: Add the date you started the experiment here (YYYY-MM-DD)
+description: "1 degree ACCESS-OM2 global model configuration under the RYF9091 Repeat\nYear Forcing strategy outlined by Stewart et al. (2020), \nhttps://doi.org/10.1016/j.ocemod.2019.101557.\nThe configuration is based on that described in Kiss et al. (2020),\nhttps://doi.org/10.5194/gmd-13-401-2020, but with many improvements.\nInitial conditions are WOA13v2 potential temperature and practical salinity.\nRun with JRA55-do v1.4.0 RYF9091 (1 May 1990 - 30 April 1991) repeated forcing\nwith all solid runoff converted to liquid runoff with no heat transfer.\nSpin up starts from a nominal year of 1 Jan 1900."
+notes: |-
+  COSIMA request that users of this or other ACCESS-OM2 model code or output data:
+  (a) consider citing Kiss et al. (2020) [http://doi.org/10.5194/gmd-13-401-2020]
+  (b) include an acknowledgement such as the following:
+  "The authors thank the Consortium for Ocean-Sea Ice Modelling in Australia (COSIMA; http://www.cosima.org.au)
+  for making the ACCESS-OM2 suite of models available at https://github.com/COSIMA/access-om2.
+  Model runs were undertaken with the assistance of resources from the National Computational Infrastructure (NCI),
+  which is supported by the Australian Government."
+  (c) let COSIMA know of any publications which use these models or data so they can add them to their list:
+  https://scholar.google.com/citations?hl=en&user=inVqu_4AAAAJ
+keywords:
+  - JRA55
+  - access-om2
+  - repeat-year
+  - global
+realm:
+  - ocean
+  - seaIce
+nominal_resolution: 100 km
+reference: https://doi.org/10.5194/gmd-13-401-2020
+license: CC-BY-4.0
+model: access-om2
+version: "2.0"
+url: https://github.com/ACCESS-NRI/access-om2-configs/tree/release-1deg_jra55_ryf

--- a/tests/test_test_access_om2_config.py
+++ b/tests/test_test_access_om2_config.py
@@ -1,13 +1,16 @@
 import os
 import shlex
+import shutil
 import subprocess
 from pathlib import Path
+
+import yaml
 
 HERE = os.path.dirname(__file__)
 RESOURCES_DIR = Path(f"{HERE}/resources")
 
 
-def test_test_access_om2_config_release_jra55_ryf():
+def test_test_access_om2_config_release_1deg_jra55_ryf():
     """Test ACCESS-OM2 specific config tests"""
     access_om2_configs = RESOURCES_DIR / "access-om2" / "configurations"
     test_config = access_om2_configs / "release-1deg_jra55_ryf"
@@ -16,11 +19,77 @@ def test_test_access_om2_config_release_jra55_ryf():
 
     test_cmd = (
         "model-config-tests -s "
-        # Use -k to select one test
+        # Run all access_om2 specific tests
         "-m access_om2 "
         f"--control-path {test_config} "
         # Use target branch as can't mock get_git_branch function in utils
         f"--target-branch release-1deg_jra55_ryf"
+    )
+
+    result = subprocess.run(shlex.split(test_cmd), capture_output=True, text=True)
+
+    # Expect the tests to have passed
+    if result.returncode:
+        # Print out test logs if there are errors
+        print(f"Test stdout: {result.stdout}\nTest stderr: {result.stderr}")
+
+    assert result.returncode == 0
+
+
+def test_test_access_om2_config_modified_module_version(tmp_path):
+    """Test changing model module version in config.yaml,
+    will cause tests to fail if paths in exe manifests don't
+    match released spack.location file"""
+    access_om2_configs = RESOURCES_DIR / "access-om2" / "configurations"
+
+    # Copy test configuration
+    test_config = access_om2_configs / "release-1deg_jra55_ryf"
+    mock_control_path = tmp_path / "mock_control_path"
+    shutil.copytree(test_config, mock_control_path)
+
+    mock_config = mock_control_path / "config.yaml"
+
+    with open(mock_config) as f:
+        config = yaml.safe_load(f)
+
+    # Use a different released version of access-om2 module
+    config["modules"]["load"] = ["access-om2/2023.11.23"]
+
+    with open(mock_config, "w") as f:
+        yaml.dump(config, f)
+
+    test_cmd = (
+        "model-config-tests -s "
+        # Only test the manifest exe in release spack location test
+        "-k test_access_om2_manifest_exe_in_release_spack_location "
+        f"--control-path {mock_control_path} "
+        # Use target branch as can't mock get_git_branch function in utils
+        f"--target-branch release-1deg_jra55_ryf"
+    )
+
+    result = subprocess.run(shlex.split(test_cmd), capture_output=True, text=True)
+
+    # Expect test to have failed
+    assert result.returncode == 1
+    error_msg = "Expected exe path in exe manifest to match an install path in released spack.location"
+    assert error_msg in result.stdout
+
+
+def test_test_access_om2_config_dev_025deg_jra55_iaf_bgc():
+    """Test ACCESS-OM2 specific config tests for
+    high-degree (025deg) and BGC configurations"""
+    access_om2_configs = RESOURCES_DIR / "access-om2" / "configurations"
+    test_config = access_om2_configs / "dev-025deg_jra55_iaf_bgc"
+
+    assert test_config.exists()
+
+    test_cmd = (
+        "model-config-tests -s "
+        # Run all access_om2 specific tests
+        "-m access_om2 "
+        f"--control-path {test_config} "
+        # Use target branch as can't mock get_git_branch function in utils
+        f"--target-branch release-025deg_jra55_iaf_bgc"
     )
 
     result = subprocess.run(shlex.split(test_cmd), capture_output=True, text=True)

--- a/tests/test_test_access_om2_config.py
+++ b/tests/test_test_access_om2_config.py
@@ -1,0 +1,33 @@
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+HERE = os.path.dirname(__file__)
+RESOURCES_DIR = Path(f"{HERE}/resources")
+
+
+def test_test_access_om2_config_release_jra55_ryf():
+    """Test ACCESS-OM2 specific config tests"""
+    access_om2_configs = RESOURCES_DIR / "access-om2" / "configurations"
+    test_config = access_om2_configs / "release-1deg_jra55_ryf"
+
+    assert test_config.exists()
+
+    test_cmd = (
+        "model-config-tests -s "
+        # Use -k to select one test
+        "-m access_om2 "
+        f"--control-path {test_config} "
+        # Use target branch as can't mock get_git_branch function in utils
+        f"--target-branch release-1deg_jra55_ryf"
+    )
+
+    result = subprocess.run(shlex.split(test_cmd), capture_output=True, text=True)
+
+    # Expect the tests to have passed
+    if result.returncode:
+        # Print out test logs if there are errors
+        print(f"Test stdout: {result.stdout}\nTest stderr: {result.stderr}")
+
+    assert result.returncode == 0

--- a/tests/test_test_config.py
+++ b/tests/test_test_config.py
@@ -1,0 +1,31 @@
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+HERE = os.path.dirname(__file__)
+RESOURCES_DIR = Path(f"{HERE}/resources")
+
+
+def test_test_config_access_om2():
+    """Test general config tests using an ACCESS-OM2 configuration"""
+    access_om2_configs = RESOURCES_DIR / "access-om2" / "configurations"
+    test_config = access_om2_configs / "release-1deg_jra55_ryf"
+
+    assert test_config.exists()
+
+    test_cmd = (
+        "model-config-tests -s "
+        # Use -k to select one test
+        "-m config "
+        f"--control-path {test_config} "
+    )
+
+    result = subprocess.run(shlex.split(test_cmd), capture_output=True, text=True)
+
+    # Expect the tests to have passed
+    if result.returncode:
+        # Print out test logs if there are errors
+        print(f"Test stdout: {result.stdout}\nTest stderr: {result.stderr}")
+
+    assert result.returncode == 0

--- a/tests/test_test_config.py
+++ b/tests/test_test_config.py
@@ -8,7 +8,7 @@ RESOURCES_DIR = Path(f"{HERE}/resources")
 
 
 def test_test_config_access_om2():
-    """Test general config tests using an ACCESS-OM2 configuration"""
+    """Test general config tests using a skeleton ACCESS-OM2 configuration"""
     access_om2_configs = RESOURCES_DIR / "access-om2" / "configurations"
     test_config = access_om2_configs / "release-1deg_jra55_ryf"
 
@@ -16,7 +16,7 @@ def test_test_config_access_om2():
 
     test_cmd = (
         "model-config-tests -s "
-        # Use -k to select one test
+        # Run all general config tests
         "-m config "
         f"--control-path {test_config} "
     )


### PR DESCRIPTION
In an upcoming version of payu, model modules with be loaded using `modules use/load` in payu config.yaml files, and exe paths for the model/submodel will then be determined by payu using the PATHs added by the module. 

- Removed QA tests for absolute executables paths in config.yaml files, and checking full paths in manifests
- Instead find the module version in config.yaml, and use that to find the released `spack.location` file. Then check the executable paths in manifests match an install path in the `spack.location`, as described in #18
- As ACCESS-OM2 has different repository and module for BGC configurations, and the only way to determine that has been checking if "bgc" is in the branch name, the above test has been moved into model specific tests.
- Added a start of ESM1.5 specific QA test class - under `access_esm1p5` marker
- Added tests for access-om2 configurations - added skeleton files on two configurations to test low/high-res + bgc/non-bgc specific tests. While I was at it, also added a test for bit repro historical for access-om2 using a test resource configuration to check runtime and the checksum file were set as expected.
- Added test for module in released configurations be `/g/data/vk83/modules/access-models`( For example for access-om2 rather than `/g/data/vk83/apps/spack/0.20/release/modules/linux-rocky8-x86_64`)

This requires a new release of payu - as need changes to find exe paths using modules.

This test will fail if using prerelease modules, as there is not a released `spack.location` file. 

Closes #18, Closes #29
