### PR TITLE
Fix `configs-ci` `!bump` command

### DIFF
--- a/.github/workflows/config-pr-2-confirm.yml
+++ b/.github/workflows/config-pr-2-confirm.yml
@@ -43,6 +43,8 @@ jobs:
         # Since the trigger for this workflow was on.issue_comment, we need
         # to do a bit more wrangling to checkout the pull request
         id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: gh pr checkout ${{ github.event.issue.number }}
 
       - name: Get Type of Bump


### PR DESCRIPTION
See failed run: https://github.com/ACCESS-NRI/access-om2-configs/actions/runs/9866119810/job/27244325155#step:4:10

This was a regression from moving the configs from `access-om2-configs` into `model-config-tests`. 

In this PR:
* Add back the `env.GH_TOKEN` to the `gh` run command. 