### PR TITLE
Update other tokens used for `gh` commands

### DIFF
--- a/.github/workflows/config-pr-2-confirm.yml
+++ b/.github/workflows/config-pr-2-confirm.yml
@@ -104,6 +104,7 @@ jobs:
       pull-requests: write
     env:
       ARTIFACT_LOCAL_LOCATION: /opt/artifact
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
A similar regression that was found in https://github.com/ACCESS-NRI/model-config-tests/pull/31
See failed run: https://github.com/ACCESS-NRI/access-om2-configs/actions/runs/9866828779/job/27246236631

In this PR:
* Add back the `env.GH_TOKEN` when using `gh` commands