### PR TITLE
Checksum Links in Comments

### DIFF
--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -300,8 +300,11 @@ jobs:
             <summary> Further information</summary>
 
             The experiment can be found on Gadi at `${{ needs.repro-ci.outputs.experiment-location }}`, and the test results at ${{ needs.check-checksum.outputs.check-run-url }}.
+
             The checksums generated in this PR are found in the `testing/checksum` directory of ${{ needs.repro-ci.outputs.artifact-url }}.
+
             ${{ env.COMPARED_CHECKSUM_STRING }}
+
             </details>
 
       - name: Failed Repro Comment
@@ -316,6 +319,9 @@ jobs:
             <summary> Further information</summary>
 
             The experiment can be found on Gadi at `${{ needs.repro-ci.outputs.experiment-location }}`, and the test results at ${{ needs.check-checksum.outputs.check-run-url }}.
+
             The checksums generated in this PR are found in the `testing/checksum` directory of ${{ needs.repro-ci.outputs.artifact-url }}.
+
             ${{ env.COMPARED_CHECKSUM_STRING }}
+
             </details>

--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -210,7 +210,7 @@ jobs:
       compared-checksum-version: ${{ steps.results.outputs.compared-checksum-version }}
     steps:
       - name: Download Newly Created Checksum
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.repro-ci.outputs.artifact-name }}
           path: ${{ env.TESTING_LOCAL_LOCATION }}
@@ -285,21 +285,37 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    env:
+      COMPARED_CHECKSUM_STRING: ${{ needs.check-checksum.outputs.compared-checksum-version != '' && format('The checksums compared against are found here {0}/{1}/tree/{2}/testing/checksum', github.server_url, github.repository, needs.check-checksum.outputs.compared-checksum-version) || '' }}
     steps:
-      - name: Successful Release Comment
+      - name: Successful Repro Comment
         if: needs.check-checksum.outputs.result == 'pass'
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
-            :white_check_mark: The Bitwise Reproducibility check succeeded when comparing against `${{ needs.check-checksum.outputs.compared-checksum-version }}` for this `Release` config. :white_check_mark:
-            For further information, the experiment can be found on Gadi at ${{ needs.repro-ci.outputs.experiment-location }}, and the test results at ${{ needs.check-checksum.outputs.check-run-url }}.
+            :white_check_mark: The Bitwise Reproducibility check succeeded when comparing against `${{ needs.check-checksum.outputs.compared-checksum-version }}` :white_check_mark:
             You must bump the minor version of this configuration - to bump the version, comment `!bump minor` or modify the `version` in `metadata.yaml`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
 
-      - name: Failed Release Comment
+            <details>
+            <summary> Further information</summary>
+
+            The experiment can be found on Gadi at `${{ needs.repro-ci.outputs.experiment-location }}`, and the test results at ${{ needs.check-checksum.outputs.check-run-url }}.
+            The checksums generated in this PR are found in the `testing/checksum` directory of ${{ needs.repro-ci.outputs.artifact-url }}.
+            ${{ env.COMPARED_CHECKSUM_STRING }}
+            </details>
+
+      - name: Failed Repro Comment
         if: needs.check-checksum.outputs.result == 'fail'
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
-            :x: The Bitwise Reproducibility check failed when comparing against `${{ needs.check-checksum.outputs.compared-checksum-version }}` for this `Release` config. :x:
-            For further information, the experiment can be found on Gadi at ${{ needs.repro-ci.outputs.experiment-location }}, and the test results at ${{ needs.check-checksum.outputs.check-run-url }}.
-            You must bump the major version of this configuration before this PR is merged to account for this - to bump the version, comment `!bump major`or modify the `version` in `metadata.yaml`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
+            :x: The Bitwise Reproducibility check failed ${{ needs.check-checksum.outputs.compared-checksum-version != '' && format('when comparing against `{0}`', needs.check-checksum.outputs.compared-checksum-version) || 'as there is no earlier checksum to compare against' }} :x:
+            You must bump the major version of this configuration - to bump the version, comment `!bump major`or modify the `version` in `metadata.yaml`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
+
+            <details>
+            <summary> Further information</summary>
+
+            The experiment can be found on Gadi at `${{ needs.repro-ci.outputs.experiment-location }}`, and the test results at ${{ needs.check-checksum.outputs.check-run-url }}.
+            The checksums generated in this PR are found in the `testing/checksum` directory of ${{ needs.repro-ci.outputs.artifact-url }}.
+            ${{ env.COMPARED_CHECKSUM_STRING }}
+            </details>

--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -71,7 +71,7 @@ jobs:
       compared-checksum-version: ${{ steps.results.outputs.compared-checksum-version }}
     steps:
       - name: Download Newly Created Checksum
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.repro-ci.outputs.artifact-name }}
           path: ${{ env.TESTING_LOCAL_LOCATION }}
@@ -129,13 +129,14 @@ jobs:
           GH_REPO: ${{ github.repository }}
           BODY: |
             There was a failure of a monthly reproducibility check on `${{ github.repository }}`.
-            Logs, checksums and other artifacts can be found at the Failed Run Log link below.
 
             Model: `${{ steps.variables.outputs.model }}`, found here: ${{ steps.variables.outputs.model-url }}
             Config Repo: `${{ steps.variables.outputs.config }}`, found here: ${{ steps.variables.outputs.config-url }}
             Config Tag Tested for Reproducibility: `${{ needs.check-checksum.outputs.compared-checksum-version }}`, found here: ${{ steps.variables.outputs.tag-url }}
             Failed Run Log: ${{ steps.variables.outputs.run-url }}
             Experiment Location (Gadi): `${{ needs.repro-ci.outputs.experiment-location }}`
+            Checksums created: In the `testing/checksum` directory of ${{ needs.repro-ci.outputs.artifact-url }}
+            Checksums compared against: ${{ format('{0}/{1}/tree/{2}/testing/checksum', github.server_url, github.repository, needs.check-checksum.outputs.compared-checksum-version) }}
 
             Tagging @ACCESS-NRI/model-release
         run: |

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -40,6 +40,7 @@ jobs:
     environment: ${{ inputs.environment-name }}
     outputs:
       artifact-name: ${{ steps.artifact.outputs.name }}
+      artifact-url: ${{ steps.upload.outputs.artifact-url }}
       experiment-location: ${{ steps.run.outputs.experiment-location }}
     env:
       EXPERIMENT_LOCATION: ${{ vars.EXPERIMENTS_LOCATION }}/${{ github.event.repository.name }}/${{ inputs.config-tag }}
@@ -112,7 +113,8 @@ jobs:
         run: echo "name=${{ github.event.repository.name }}-${{ inputs.config-tag }}" >> $GITHUB_OUTPUT
 
       - name: Upload Test Output
-        uses: actions/upload-artifact@v3
+        id: upload
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifact.outputs.name }}
           if-no-files-found: error


### PR DESCRIPTION
In this PR:
* Updated `artifact-[upload|download]` action versions
* Repro result comments now give links to the newly-created and compared (if they exist) checksums
* And so does the issue if a scheduled check fails

References #33 