### PR TITLE
Compare Checksum from `release-*` rather then the PR Branch

### DIFF
--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -74,17 +74,24 @@ jobs:
     name: Read CI Testing Configuration
     runs-on: ubuntu-latest
     outputs:
+      # QA Test Outputs
       qa-markers: ${{ steps.qa-config.outputs.markers }}
       qa-python-version: ${{ steps.qa-config.outputs.python-version }}
       qa-model-config-tests-version: ${{ steps.qa-config.outputs.model-config-tests-version }}
+      # Repro Test Outputs
       repro-markers: ${{ steps.repro-config.outputs.markers }}
       repro-python-version: ${{ steps.repro-config.outputs.python-version }}
       repro-model-config-tests-version: ${{ steps.repro-config.outputs.model-config-tests-version }}
+      compared-config-tag: ${{ steps.compared.outputs.tag }}
     steps:
       - name: Checkout main
+        # We fetch the repository history because in `steps.compared` we
+        # attempt to get the last config tag.
         uses: actions/checkout@v4
         with:
           ref: main
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Validate `config/ci.json`
         uses: access-nri/schema/.github/actions/validate-with-schema@main
@@ -109,6 +116,18 @@ jobs:
           check: reproducibility
           branch-or-tag: ${{ github.base_ref }}
           config-filepath: "config/ci.json"
+
+      - name: Get Config Tag to Compare Against
+        id: compared
+        # We checkout the base branch (the branch that will be merged into)
+        # to get the last tagged configuration checksums.
+        # We could also just take the HEAD of the base_ref, which would give
+        # the same result, but tags are human readable.
+        # In the case where there is no tag, `tag` will be an empty string,
+        # which is handled later.
+        run: |
+          git checkout ${{ github.base_ref }}
+          echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
 
   qa-ci:
     # Run quick, non-HPC tests on the runner.
@@ -180,8 +199,10 @@ jobs:
     if: needs.commit-check.outputs.authorship != vars.GH_ACTIONS_BOT_GIT_USER_NAME && needs.branch-check.result == 'success'
     uses: access-nri/model-config-tests/.github/workflows/test-repro.yml@main
     with:
+      # FIXME: Make the environment name an input of some kind - what if we deploy to a different supercomputer?
       environment-name: Gadi
-      config-tag: ${{ github.head_ref }}
+      config-ref: ${{ github.head_ref }}
+      compared-config-ref: ${{ needs.config.outputs.compared-config-tag }}
       test-markers: ${{ needs.config.outputs.repro-markers }}
       model-config-tests-version: ${{ needs.config.outputs.repro-model-config-tests-version }}
       python-version: ${{ needs.config.outputs.repro-python-version }}
@@ -196,8 +217,6 @@ jobs:
       - repro-ci
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
       checks: write
     env:
       TESTING_LOCAL_LOCATION: /opt/testing
@@ -206,20 +225,12 @@ jobs:
       check-run-url: ${{ steps.results.outputs.check-url }}
       # Overall result of the checksum repro CI - `pass` (if reproducible), `fail` otherwise
       result: ${{ steps.results.outputs.result }}
-      # Version of the checksum compared against the newly generated one
-      compared-checksum-version: ${{ steps.results.outputs.compared-checksum-version }}
     steps:
       - name: Download Newly Created Checksum
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.repro-ci.outputs.artifact-name }}
           path: ${{ env.TESTING_LOCAL_LOCATION }}
-
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
-          fetch-tags: true
 
       - name: Parse Test Report
         id: tests
@@ -237,7 +248,6 @@ jobs:
         id: results
         run: |
           echo "check-url=${{ fromJson(steps.tests.outputs.json).check_url }}" >> $GITHUB_OUTPUT
-          echo "compared-checksum-version=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
           if [ "${{ fromJson(steps.tests.outputs.json).stats.tests_fail }}" > 0 ]; then
             echo "result=fail" >> $GITHUB_OUTPUT
           else
@@ -280,6 +290,7 @@ jobs:
     name: Repro Result Notifier
     # Notify the PR of the result of the Repro check
     needs:
+      - config
       - repro-ci
       - check-checksum
     runs-on: ubuntu-latest

--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -43,8 +43,10 @@ jobs:
       - config
     uses: access-nri/model-config-tests/.github/workflows/test-repro.yml@main
     with:
+      # FIXME: Make the environment name an input of some kind - what if we deploy to a different supercomputer?
       environment-name: Gadi
-      config-tag: ${{ inputs.config-tag }}
+      config-ref: ${{ inputs.config-tag }}
+      compared-config-ref: ${{ inputs.config-tag }}
       test-markers: ${{ needs.config.outputs.markers }}
       model-config-tests-version: ${{ needs.config.outputs.model-config-tests-version }}
       python-version: ${{ needs.config.outputs.python-version }}

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -105,8 +105,8 @@ jobs:
             --junitxml=${{ env.EXPERIMENT_LOCATION }}/checksum/test_report.xml
 
           # Deactivate and remove the test virtual environment
-          # TODO: Do we need to deactivate the venv if we are about to logout?
           deactivate
+          rm -rf ${{ env.TEST_VENV_LOCATION }}
 
           # We want the exit code post-`pytest` to be 0 so the overall `ssh` call succeeeds
           # after a potential `pytest` error.

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -67,9 +67,9 @@ jobs:
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash<<'EOT'
 
-          # Remove base experiment if it already exists
-          if [ -d "${{ env.BASE_EXPERIMENT_LOCATION }}" ]; then
-            rm -rf ${{ env.BASE_EXPERIMENT_LOCATION }}
+          # Remove base experiment (and everything else) if it exists
+          if [ -d "${{ env.EXPERIMENT_LOCATION }}" ]; then
+            rm -rf ${{ env.EXPERIMENT_LOCATION }}/*
           fi
 
           # Setup a base experiment
@@ -107,7 +107,6 @@ jobs:
           # Deactivate and remove the test virtual environment
           # TODO: Do we need to deactivate the venv if we are about to logout?
           deactivate
-          rm -rf ${{ env.TEST_VENV_LOCATION }}
 
           # We want the exit code post-`pytest` to be 0 so the overall `ssh` call succeeeds
           # after a potential `pytest` error.

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -2,10 +2,14 @@ name: Repro Checks
 on:
   workflow_call:
     inputs:
-      config-tag:
+      config-ref:
         type: string
         required: true
-        description: A tag on an associated config branch to use for the reproducibility run
+        description: A commit or tag on an associated config branch to use for the reproducibility run
+      compared-config-ref:
+        type: string
+        required: false
+        description: A commit or tag on an associated config branch to compare against
       environment-name:
         type: string
         required: true
@@ -35,7 +39,7 @@ jobs:
   repro:
     # NOTE: A lot of these `vars` and `secrets` are not found in this repository. Instead, they are inherited
     # from the calling workflow (for example, `ACCESS-NRI/access-om2-configs`)
-    name: Run ${{ inputs.config-tag }}
+    name: Run Config On ${{ inputs.config-ref }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment-name }}
     outputs:
@@ -43,7 +47,7 @@ jobs:
       artifact-url: ${{ steps.upload.outputs.artifact-url }}
       experiment-location: ${{ steps.run.outputs.experiment-location }}
     env:
-      EXPERIMENT_LOCATION: ${{ vars.EXPERIMENTS_LOCATION }}/${{ github.event.repository.name }}/${{ inputs.config-tag }}
+      EXPERIMENT_LOCATION: ${{ vars.EXPERIMENTS_LOCATION }}/${{ github.event.repository.name }}/${{ inputs.config-ref }}
     steps:
       - name: Setup SSH
         id: ssh
@@ -58,6 +62,7 @@ jobs:
         id: run
         env:
           BASE_EXPERIMENT_LOCATION: ${{ env.EXPERIMENT_LOCATION }}/base-experiment
+          COMPARED_CHECKSUM_LOCATION: ${{ env.EXPERIMENT_LOCATION }}/compared
           TEST_VENV_LOCATION: ${{ env.EXPERIMENT_LOCATION }}/test-venv
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash<<'EOT'
@@ -68,9 +73,14 @@ jobs:
           fi
 
           # Setup a base experiment
-          git clone ${{ github.event.repository.clone_url }} ${{ env.BASE_EXPERIMENT_LOCATION }}
+          git clone ${{ github.event.repository.clone_url }} ${{ env.BASE_EXPERIMENT_LOCATION }} -b ${{ inputs.config-ref }}
           cd ${{ env.BASE_EXPERIMENT_LOCATION }}
-          git checkout ${{ inputs.config-tag }}
+
+          # Setup a compared checksum (if it exists)
+          if [ -n "${{ inputs.compared-config-ref }}" ]; then
+            git clone ${{ github.event.repository.clone_url }} ${{ env.COMPARED_CHECKSUM_LOCATION }} -b ${{ inputs.compared-config-ref }}
+            COMPARED_CHECKSUM_FILE=$(find ${{ env.COMPARED_CHECKSUM_LOCATION }} -type f -name 'historical-*hr-checksum.json')
+          fi
 
           # Load Python module
           module load python3/${{ inputs.python-version }}
@@ -87,12 +97,15 @@ jobs:
           # after this step.
           set +e
 
-          # Run model-config-tests pytests - this also generates checksums files
+          # Run model-config-tests pytests - this also generates checksums files.
+          # If there is a checksum to compare against, add --checksum-path arg.
           model-config-tests -s -m "${{ inputs.test-markers }}" \
             --output-path ${{ env.EXPERIMENT_LOCATION }} \
+            ${{ inputs.compared-config-ref != '' && '--checksum-path $COMPARED_CHECKSUM_FILE \' || '\' }}
             --junitxml=${{ env.EXPERIMENT_LOCATION }}/checksum/test_report.xml
 
           # Deactivate and remove the test virtual environment
+          # TODO: Do we need to deactivate the venv if we are about to logout?
           deactivate
           rm -rf ${{ env.TEST_VENV_LOCATION }}
 
@@ -110,7 +123,7 @@ jobs:
 
       - name: Generate Test Output Artifact Name
         id: artifact
-        run: echo "name=${{ github.event.repository.name }}-${{ inputs.config-tag }}" >> $GITHUB_OUTPUT
+        run: echo "name=${{ github.event.repository.name }}-${{ inputs.config-ref }}" >> $GITHUB_OUTPUT
 
       - name: Upload Test Output
         id: upload

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -80,6 +80,15 @@ jobs:
           if [ -n "${{ inputs.compared-config-ref }}" ]; then
             git clone ${{ github.event.repository.clone_url }} ${{ env.COMPARED_CHECKSUM_LOCATION }} -b ${{ inputs.compared-config-ref }}
             COMPARED_CHECKSUM_FILE=$(find ${{ env.COMPARED_CHECKSUM_LOCATION }} -type f -name 'historical-*hr-checksum.json')
+
+            # Error checking...
+            if [ -z "$COMPARED_CHECKSUM_FILE" ]; then
+              echo '::error::Did not find a `testing/checksum/historical-*hr-checksum.json` file in ${{ inputs.compared-config-ref }}. Exiting.'
+              exit 1
+            elif [ $(echo "$COMPARED_CHECKSUM_FILE" | wc -w) -gt 1 ]; then
+              echo '::error::Found more than one `testing/checksum/historical-*hr-checksum.json` file in ${{ inputs.compared-config-ref }}. Exiting.'
+              exit 2
+            fi
           fi
 
           # Load Python module


### PR DESCRIPTION
We currently have to rebase `dev-*` onto `release-*` every configuration release, in order to compare the next config update against the one just released. This is because we use the `dev-*` branches `testing/checksum/historical-*hr-checksum.json` file to compare against the newly created checksum, as that is the default `--checksum-path` of `model-configs-test`. 

Now, `test-repro.yml` can select which branch (or config tag) we want to compare against explicitly, rather than relying on a `model-configs-test` default. 

In this PR:
* Update `test-repro.yml` to take in a renamed `config-tag`->`config-ref` input and a new optional `compared-config-ref` input, which more explicitly notes that one config-ref will be compared with another, rather than relying on the default `--checksum-path` of `./testing/checksum/`.
* Updated all workflows that refer to the updated `test-repro.yml`. 
* Added comments! 
* In https://github.com/ACCESS-NRI/model-config-tests/commit/0646a1ddc7b29a26693ff97331a21074571c7f83, instead of just deleting `${{ env.EXPERIMENT_LOCATION }}/base-experiment` and `${{ env.EXPERIMENT_LOCATION }}/test-venv` separately, delete everything in `${{ env.EXPERIMENT_LOCATION }}/*`. Will need @jo-basevi s opinion on this one before merging! 

References #33 