### PR TITLE
`ACCESS-OM3`: Empty QA Checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "model_config_tests"
-version = "0.0.1"
+version = "0.0.2"
 authors = [
   { name = "ACCESS-NRI" },
 ]

--- a/src/model_config_tests/conftest.py
+++ b/src/model_config_tests/conftest.py
@@ -120,3 +120,6 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "access_om2: mark as access-om2 specific tests in quick QA CI checks"
     )
+    config.addinivalue_line(
+        "markers", "access_om3: mark as access-om3 specific tests in quick QA CI checks"
+    )

--- a/src/model_config_tests/test_access_om3_config.py
+++ b/src/model_config_tests/test_access_om3_config.py
@@ -1,0 +1,13 @@
+# Copyright 2024 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ACCESS-OM3 specific configuration tests"""
+
+import pytest
+
+@pytest.mark.access_om3
+class TestAccessOM3:
+    """ACCESS-OM3 Specific configuration and metadata tests"""
+
+    def test_pass(self):
+        pass

--- a/src/model_config_tests/test_access_om3_config.py
+++ b/src/model_config_tests/test_access_om3_config.py
@@ -5,6 +5,7 @@
 
 import pytest
 
+
 @pytest.mark.access_om3
 class TestAccessOM3:
     """ACCESS-OM3 Specific configuration and metadata tests"""


### PR DESCRIPTION
We add empty OM3 QA checks in order to pass the QA section of the workflow for `ACCESS-OM3`. This PR will require a bump to the `model-config-tests` package version (from `0.0.1` to `0.0.2`.

In this PR:
* Add empty OM3 QA test cases
* Add new `access_om3` pytest marker
* Update version to `0.0.2`

 