### PR TITLE
`ACCESS-ESM1.5` Further Test Fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "model_config_tests"
-version = "0.0.4"
+version = "0.0.5"
 authors = [
   { name = "ACCESS-NRI" },
 ]

--- a/src/model_config_tests/qa/test_access_esm1p5_config.py
+++ b/src/model_config_tests/qa/test_access_esm1p5_config.py
@@ -104,7 +104,7 @@ class TestAccessEsm1p5:
         )
 
     @pytest.mark.parametrize(
-        "field,expected", [("realm", VALID_REALMS), ("keyword", VALID_KEYWORDS)]
+        "field,expected", [("realm", VALID_REALMS), ("keywords", VALID_KEYWORDS)]
     )
     def test_metadata_field_equal_expected_sequence(self, field, expected, metadata):
 

--- a/src/model_config_tests/qa/test_access_esm1p5_config.py
+++ b/src/model_config_tests/qa/test_access_esm1p5_config.py
@@ -20,7 +20,7 @@ ACCESS_ESM1P5_REPOSITORY_NAME = "ACCESS-ESM1.5"
 ######################################
 # Bunch of expected values for tests #
 ######################################
-VALID_REALMS: set[str] = {"atmosphere", "land", "ocean", "ocnBgchm", "seaIce"}
+VALID_REALMS: set[str] = {"atmosphere", "land", "ocean", "ocnBgchem", "seaIce"}
 VALID_KEYWORDS: set[str] = {"global", "access-esm1.5"}
 VALID_NOMINAL_RESOLUTION: str = "100 km"
 VALID_REFERENCE: str = "https://doi.org/10.1071/ES19035"


### PR DESCRIPTION
After testing the `metadata.yaml` tests on an actual ESM1.5 configuration, it was found that more expected fields were actually incorrect. 

In this PR:
* Change 'ocnBgchm' to 'ocnBgchem'
* Change 'keyword' to 'keywords'
* Update version of `model-config-tests` to `0.0.5`