### PR TITLE
Changed `VALID_REALMS` field from 'atmosphere' to 'atmos'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "model_config_tests"
-version = "0.0.5"
+version = "0.0.6"
 authors = [
   { name = "ACCESS-NRI" },
 ]

--- a/src/model_config_tests/qa/test_access_esm1p5_config.py
+++ b/src/model_config_tests/qa/test_access_esm1p5_config.py
@@ -20,7 +20,7 @@ ACCESS_ESM1P5_REPOSITORY_NAME = "ACCESS-ESM1.5"
 ######################################
 # Bunch of expected values for tests #
 ######################################
-VALID_REALMS: set[str] = {"atmosphere", "land", "ocean", "ocnBgchem", "seaIce"}
+VALID_REALMS: set[str] = {"atmos", "land", "ocean", "ocnBgchem", "seaIce"}
 VALID_KEYWORDS: set[str] = {"global", "access-esm1.5"}
 VALID_NOMINAL_RESOLUTION: str = "100 km"
 VALID_REFERENCE: str = "https://doi.org/10.1071/ES19035"


### PR DESCRIPTION
Noting error here: https://github.com/ACCESS-NRI/access-esm1.5-configs/pull/43/checks?check_run_id=28637397532

In this PR:
* Updated the `VALID_REALMS` to their `CMIP7` equivalents
* Update version to `0.0.6`