### PR TITLE
`ACCESS-ESM1.5` `mppnccombine` MPI Test Fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "model_config_tests"
-version = "0.0.6"
+version = "0.0.7"
 authors = [
   { name = "ACCESS-NRI" },
 ]

--- a/src/model_config_tests/qa/test_access_esm1p5_config.py
+++ b/src/model_config_tests/qa/test_access_esm1p5_config.py
@@ -185,6 +185,9 @@ class TestAccessEsm1p5:
                 "collate.mpi", "config.yaml"
             )
 
-            assert config["collate"]["mpi"], error_field_incorrect(
-                "collate.mpi", "config.yaml", "true"
+            # Loading the yaml into a dict also converts
+            # `collate.mpi:true`/`collate.mpi:false` to `True`/`False` so we
+            # can assert if it is a `bool`.
+            assert isinstance(config["collate"]["mpi"], bool), error_field_incorrect(
+                "collate.mpi", "config.yaml", "true or false"
             )


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/access-esm1.5-configs/pull/44/checks?check_run_id=28688143378

We allow `collate.mpi` to be either `true` or `false`, rather than only `true`. 

Since converting the `.yaml` file into a Python `dict` also converts the above to a `bool`, test that the resulting value is an instance of `bool`.

In this PR:
* Update the test
* Update the version of `model-config-tests` to `0.0.7` 