### PR TITLE
Build repro test environments using payu modules

### DIFF
--- a/.github/actions/parse-ci-config/README.md
+++ b/.github/actions/parse-ci-config/README.md
@@ -16,7 +16,8 @@ This action parses the CI testing configuration file. The caller of the action n
 | ---- | ---- | ----------- | -------- |
 | markers | `string` | Markers used for the pytest checks, in the python format | `checksum` |
 | model-config-tests-version | `string` | The version of the model-config-tests | `0.0.1` |
-| python-version | `string` | The python version used to create test virtual environment | `3.11.0` |
+| python-version | `string` | The python version used to create local test virtual environment (e.g. QA tests) | `3.11.0` |
+| payu-version | `string` | The payu version used to create local remote test virtual environment (e.g. reproducibility tests) | `1.1.4` |
 
 ## Example usage
 
@@ -36,5 +37,3 @@ This action parses the CI testing configuration file. The caller of the action n
           branch-or-tag: "release-1deg_jra55_ryf-2.0"
           config-filepath: "config/ci.json"
 ```
-
-

--- a/.github/actions/parse-ci-config/action.yml
+++ b/.github/actions/parse-ci-config/action.yml
@@ -16,10 +16,13 @@ outputs:
     description: A version of the model-config-tests package
   python-version:
     value: ${{ steps.read-config.outputs.python-version }}
-    description: The python version used to create test virtual environment
+    description: The python version used to create test virtual environment for local tests (e.g. QA tests)
   markers:
     value: ${{ steps.read-config.outputs.markers }}
     description: A python expression of markers to pass to model-config-tests pytests
+  payu-version:
+    value: ${{ steps.read-config.outputs.payu-version }}
+    description: The payu version used to create test virtual environment for remote tests (e.g. repro tests)
 runs:
   using: "composite" 
   steps:         
@@ -40,6 +43,11 @@ runs:
             .[$check].default["python-version"] // 
             .default["python-version"]
           ),
+          "payu-version": (
+            .[$check][$branch]["payu-version"] //
+            .[$check].default["payu-version"] //
+            .default["payu-version"]
+          ),
           "markers": (
             .[$check][$branch].markers // 
             .[$check].default.markers //
@@ -50,4 +58,5 @@ runs:
         
         echo "markers=$(echo "$output" | jq -r '.["markers"]')" >> $GITHUB_OUTPUT
         echo "python-version=$(echo "$output" | jq -r '.["python-version"]')" >> $GITHUB_OUTPUT
+        echo "payu-version=$(echo "$output" | jq -r '.["payu-version"]')" >> $GITHUB_OUTPUT
         echo "model-config-tests-version=$(echo "$output" | jq -r '.["model-config-tests-version"]')" >> $GITHUB_OUTPUT

--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -80,7 +80,7 @@ jobs:
       qa-model-config-tests-version: ${{ steps.qa-config.outputs.model-config-tests-version }}
       # Repro Test Outputs
       repro-markers: ${{ steps.repro-config.outputs.markers }}
-      repro-python-version: ${{ steps.repro-config.outputs.python-version }}
+      repro-payu-version: ${{ steps.repro-config.outputs.payu-version }}
       repro-model-config-tests-version: ${{ steps.repro-config.outputs.model-config-tests-version }}
       compared-config-tag: ${{ steps.compared.outputs.tag }}
     steps:
@@ -205,7 +205,7 @@ jobs:
       compared-config-ref: ${{ needs.config.outputs.compared-config-tag }}
       test-markers: ${{ needs.config.outputs.repro-markers }}
       model-config-tests-version: ${{ needs.config.outputs.repro-model-config-tests-version }}
-      python-version: ${{ needs.config.outputs.repro-python-version }}
+      payu-version: ${{ needs.config.outputs.repro-payu-version }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       markers: ${{ steps.scheduled-config.outputs.markers }}
-      python-version: ${{ steps.scheduled-config.outputs.python-version }}
+      payu-version: ${{ steps.scheduled-config.outputs.payu-version }}
       model-config-tests-version: ${{ steps.scheduled-config.outputs.model-config-tests-version }}
     steps:
       - name: Checkout main
@@ -49,7 +49,7 @@ jobs:
       compared-config-ref: ${{ inputs.config-tag }}
       test-markers: ${{ needs.config.outputs.markers }}
       model-config-tests-version: ${{ needs.config.outputs.model-config-tests-version }}
-      python-version: ${{ needs.config.outputs.python-version }}
+      payu-version: ${{ needs.config.outputs.payu-version }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/generate-checksums.yml
+++ b/.github/workflows/generate-checksums.yml
@@ -27,10 +27,10 @@ on:
         type: string
         required: true
         description: A version of the model-config-tests package
-      python-version:
+      payu-version:
         type: string
         required: true
-        description: The python module version used to create test virtual environment
+        description: The payu module version used to create test virtual environment
     outputs:
       checksum-location:
         value: ${{ jobs.generate-checksum.outputs.checksum-location }}
@@ -78,11 +78,20 @@ jobs:
           cd ${{ env.BASE_EXPERIMENT_LOCATION }}
           git checkout ${{ inputs.config-branch-name }}
 
-           # Load Python module
-          module load python3/${{ inputs.python-version }}
+          # Load payu module
+          if [ "${{ inputs.payu-version }}" == "dev" ]; then
+            echo "::warning::Using the prerelease module payu/dev for testing"
+            module use ${{ vars.PRERELEASE_MODULE_LOCATION }}
+          else
+            module use ${{ vars.MODULE_LOCATION }}
+          fi
+          module load payu/${{ inputs.payu-version }}
 
-          # Create and activate virtual environment
-          python3 -m venv ${{ env.TEST_VENV_LOCATION }}
+          # Create testing virtual environment
+          # Note: --system-site-packages uses packages from payu modules
+          python3 -m venv ${{ env.TEST_VENV_LOCATION }} --system-site-packages
+
+          # Activate environment
           source ${{ env.TEST_VENV_LOCATION }}/bin/activate
 
           # Install model-config-tests

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -22,10 +22,10 @@ on:
         type: string
         required: true
         description: A version of the model-config-tests package
-      python-version:
+      payu-version:
         type: string
         required: true
-        description: The python module version used to create test virtual environment
+        description: The payu module version used to create test virtual environment
     outputs:
       artifact-name:
         value: ${{ jobs.repro.outputs.artifact-name }}
@@ -91,11 +91,20 @@ jobs:
             fi
           fi
 
-          # Load Python module
-          module load python3/${{ inputs.python-version }}
+          # Load payu module
+          if [ "${{ inputs.payu-version }}" == "dev" ]; then
+            echo "::warning::Using the prerelease module payu/dev for testing"
+            module use ${{ vars.PRERELEASE_MODULE_LOCATION }}
+          else
+            module use ${{ vars.MODULE_LOCATION }}
+          fi
+          module load payu/${{ inputs.payu-version }}
 
-          # Create and activate virtual environment
-          python3 -m venv ${{ env.TEST_VENV_LOCATION }}
+          # Create testing virtual environment
+          # Note: --system-site-packages uses packages from payu modules
+          python3 -m venv ${{ env.TEST_VENV_LOCATION }} --system-site-packages
+
+          # Activate environment
           source ${{ env.TEST_VENV_LOCATION }}/bin/activate
 
           # Install model-config-tests

--- a/README.md
+++ b/README.md
@@ -11,24 +11,34 @@ bit reproducibility tests](https://github.com/COSIMA/access-om2/blob/master/test
 
 ### How to run pytests manually on NCI
 
-1. Create and activate a python virtual environment for installing and running tests
+1. Load payu module - this provides the dependencies needed to run the model
+
     ```sh
-    module load python3/3.11.0
-    python3 -m venv <path/to/test-venv>
+    module use /g/data/vk83/modules
+    module load payu/1.1.4
+    ```
+
+2. Create and activate a python virtual environment for installing and running tests
+
+    ```sh
+    python3 -m venv <path/to/test-venv> --system-site-packages
     source <path/to/test-venv>/bin/activate
     ```
 
-2. Either pip install a released version of `model-config-tests`,
+3. Either pip install a released version of `model-config-tests`,
+
     ```sh
     pip install model-config-tests==0.0.1
     ```
+
     Or to install `model-config-tests` in "editable" mode, first clone the repository, and then run pip install from the repository. This means any changes to the code are reflected in the installed package.
+
     ```sh
     git clone https://github.com/ACCESS-NRI/model-config-tests/ <path/to/model-config-tests>
     pip install -e <path/to/model-config-tests>
     ```
 
-3. Checkout an experiment (in this case it is using an ACCESS-OM2 config)
+4. Checkout an experiment (in this case it is using an ACCESS-OM2 config)
 
     ```sh
     git clone https://github.com/ACCESS-NRI/access-om2-configs/ <path/to/experiment>
@@ -36,12 +46,14 @@ bit reproducibility tests](https://github.com/COSIMA/access-om2/blob/master/test
     git checkout <branch/tag>
     ```
 
-4. Run the pytests
+5. Run the pytests
+
     ```sh
     model-config-tests
     ```
 
-5. Once done with testing, deactivate the virtual environment, and if the environment is no longer needed, remove the environment
+6. Once done with testing, deactivate the virtual environment, and if the environment is no longer needed, remove the environment
+
     ```sh
     deactivate
     rm -rf <path/to/test-venv> # Deletes the test environment
@@ -124,3 +136,5 @@ Using it has some requirements outside of just filling in the inputs: One must h
 - `secrets.SSH_KEY` - private key for access to the deployment target
 - `secrets.SSH_USER` - username for access to the deployment target
 - `vars.EXPERIMENTS_LOCATION` - directory on the deployment target that will contain all the experiments used during testing of reproducibility across multiple runs of this workflow (ex. `/scratch/some/directory/experiments`)
+- `vars.MODULE_LOCATION` - directory on the deployment target that contains module files for payu used during reproducibility testing (ex. `/g/data/vk83/modules`)
+- `vars.PRERELEASE_MODULE_LOCATION` - directory on the deployment target that contains module files for development version of payu (ex. `/g/data/vk83/prerelease/modules`)


### PR DESCRIPTION
Build virtual python environments on top of payu conda environments to get access to all the packages. This will reduce size for testing environments, and `model-config-tests` do not need to keep track of specific dependencies needed to run models using payu, and model configurations can specify what payu version to run. This also allows options to run repro tests using `payu/dev` for specific branches.

Closes #37
Closes #17