### PR TITLE
Fix Successful Repro Pipeline Errors

### DIFF
--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -301,14 +301,15 @@ jobs:
     permissions:
       pull-requests: write
     env:
-      COMPARED_CHECKSUM_STRING: ${{ needs.check-checksum.outputs.compared-checksum-version != '' && format('The checksums compared against are found here {0}/{1}/tree/{2}/testing/checksum', github.server_url, github.repository, needs.check-checksum.outputs.compared-checksum-version) || '' }}
+      COMPARED_TAG: ${{ needs.config.outputs.compared-config-tag }}
+      COMPARED_CHECKSUM_STRING: ${{ needs.config.outputs.compared-config-tag != '' && format('The checksums compared against are found here {0}/{1}/tree/{2}/testing/checksum', github.server_url, github.repository, needs.config.outputs.compared-config-tag) || '' }}
     steps:
       - name: Successful Repro Comment
         if: needs.check-checksum.outputs.result == 'pass'
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
-            :white_check_mark: The Bitwise Reproducibility check succeeded when comparing against `${{ needs.check-checksum.outputs.compared-checksum-version }}` :white_check_mark:
+            :white_check_mark: The Bitwise Reproducibility check succeeded when comparing against `${{ env.COMPARED_TAG }}` :white_check_mark:
             You must bump the minor version of this configuration - to bump the version, comment `!bump minor` or modify the `version` in `metadata.yaml`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
 
             <details>
@@ -327,7 +328,7 @@ jobs:
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
-            :x: The Bitwise Reproducibility check failed ${{ needs.check-checksum.outputs.compared-checksum-version != '' && format('when comparing against `{0}`', needs.check-checksum.outputs.compared-checksum-version) || 'as there is no earlier checksum to compare against' }} :x:
+            :x: The Bitwise Reproducibility check failed ${{ env.COMPARED_TAG != '' && format('when comparing against `{0}`', env.COMPARED_TAG) || 'as there is no earlier checksum to compare against' }} :x:
             You must bump the major version of this configuration - to bump the version, comment `!bump major`or modify the `version` in `metadata.yaml`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
 
             <details>

--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -276,12 +276,15 @@ jobs:
           path: source
 
       - name: Modification Check
+        # If the PR branch version is different to the target branch (but isn't null or empty) then allow merging
         run: |
           target=$(yq e '.version' ./target/metadata.yaml)
           source=$(yq e '.version' ./source/metadata.yaml)
 
-          if [[ "${source}" != "${target}" && "${source}" != "null" ]]; then
-            echo "::notice::The version has been modified to ${target}. Merging is now availible"
+          echo "Comparing version target '$target' against source '$source'"
+
+          if [[ "${source}" != "${target}" && "${source}" != "null" && "${source}" != "" ]]; then
+            echo "::notice::The version has been modified to ${source}. Merging is now availible"
           else
             echo "::error::The version has not been modified in this PR. Merging is disallowed until an appropriate '!bump' is issued"
             exit 1

--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -248,7 +248,8 @@ jobs:
         id: results
         run: |
           echo "check-url=${{ fromJson(steps.tests.outputs.json).check_url }}" >> $GITHUB_OUTPUT
-          if [ "${{ fromJson(steps.tests.outputs.json).stats.tests_fail }}" > 0 ]; then
+
+          if (( ${{ fromJson(steps.tests.outputs.json).stats.tests_fail }} > 0 )); then
             echo "result=fail" >> $GITHUB_OUTPUT
           else
             echo "result=pass" >> $GITHUB_OUTPUT

--- a/.github/workflows/config-pr-2-confirm.yml
+++ b/.github/workflows/config-pr-2-confirm.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           version=$(yq '.version' metadata.yaml)
 
-          if [[ "${version}" == "null" ]]; then
+          if [[ "${version}" == "null" || "${version}" == "" ]]; then
             echo "before=null" >> $GITHUB_OUTPUT
             echo "after=1.0" >> $GITHUB_OUTPUT
             exit 0

--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -69,8 +69,6 @@ jobs:
       check-run-url: ${{ steps.results.outputs.check-url }}
       # Overall result of the checksum repro CI - `pass` (if reproducible), `fail` otherwise
       result: ${{ steps.results.outputs.result }}
-      # Version of the checksum compared against the newly generated one
-      compared-checksum-version: ${{ steps.results.outputs.compared-checksum-version }}
     steps:
       - name: Download Newly Created Checksum
         uses: actions/download-artifact@v4
@@ -93,7 +91,6 @@ jobs:
         id: results
         run: |
           echo "check-url=${{ fromJson(steps.tests.outputs.json).check_url }}" >> $GITHUB_OUTPUT
-          echo "compared-checksum-version=${{ inputs.config-tag }}" >> $GITHUB_OUTPUT
 
           if (( ${{ fromJson(steps.tests.outputs.json).stats.tests_fail }} > 0 )); then
             echo "result=fail" >> $GITHUB_OUTPUT
@@ -121,7 +118,7 @@ jobs:
           model=${config%-*}
           echo "model=$model" >> $GITHUB_OUTPUT
           echo "model-url=https://github.com/ACCESS-NRI/$model" >> $GITHUB_OUTPUT
-          echo "tag-url=https://github.com/ACCESS-NRI/$config/releases/tag/${{ needs.check-checksum.outputs.compared-checksum-version }}" >> GITHUB_OUTPUT
+          echo "tag-url=https://github.com/ACCESS-NRI/$config/releases/tag/${{ inputs.config-tag }}" >> GITHUB_OUTPUT
           echo "run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
 
           cat $GITHUB_OUTPUT
@@ -135,15 +132,15 @@ jobs:
 
             Model: `${{ steps.variables.outputs.model }}`, found here: ${{ steps.variables.outputs.model-url }}
             Config Repo: `${{ steps.variables.outputs.config }}`, found here: ${{ steps.variables.outputs.config-url }}
-            Config Tag Tested for Reproducibility: `${{ needs.check-checksum.outputs.compared-checksum-version }}`, found here: ${{ steps.variables.outputs.tag-url }}
+            Config Tag Tested for Reproducibility: `${{ inputs.config-tag }}`, found here: ${{ steps.variables.outputs.tag-url }}
             Failed Run Log: ${{ steps.variables.outputs.run-url }}
             Experiment Location (Gadi): `${{ needs.repro-ci.outputs.experiment-location }}`
             Checksums created: In the `testing/checksum` directory of ${{ needs.repro-ci.outputs.artifact-url }}
-            Checksums compared against: ${{ format('{0}/{1}/tree/{2}/testing/checksum', github.server_url, github.repository, needs.check-checksum.outputs.compared-checksum-version) }}
+            Checksums compared against: ${{ format('{0}/{1}/tree/{2}/testing/checksum', github.server_url, github.repository, inputs.config-tag) }}
 
             Tagging @ACCESS-NRI/model-release
         run: |
           gh issue create \
-            --title 'Scheduled Repro Check Failed for Config `${{ needs.check-checksum.outputs.compared-checksum-version }}`' \
+            --title 'Scheduled Repro Check Failed for Config `${{ inputs.config-tag }}`' \
             --label "type:repro-fail,priority:blocker" \
             --body '${{ env.BODY }}'

--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -94,7 +94,8 @@ jobs:
         run: |
           echo "check-url=${{ fromJson(steps.tests.outputs.json).check_url }}" >> $GITHUB_OUTPUT
           echo "compared-checksum-version=${{ inputs.config-tag }}" >> $GITHUB_OUTPUT
-          if [ "${{ fromJson(steps.tests.outputs.json).stats.tests_fail }}" -gt "0" ]; then
+
+          if (( ${{ fromJson(steps.tests.outputs.json).stats.tests_fail }} > 0 )); then
             echo "result=fail" >> $GITHUB_OUTPUT
           else
             echo "result=pass" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -30,6 +30,9 @@ on:
       artifact-name:
         value: ${{ jobs.repro.outputs.artifact-name }}
         description: Name of the artifact containing the checksums and test report for this repro run
+      artifact-url:
+        value: ${{ jobs.repro.outputs.artifact-url }}
+        description: URL to the artifact containing the checksums and test report for this repro run
       experiment-location:
         value: ${{ jobs.repro.outputs.experiment-location }}
         description: Location of the experiment on the target environment


### PR DESCRIPTION
This PR fixes a couple of errors found when a config successfully reproduces, namely:
- There was a comment saying repro had failed when it had actually succeeded, due to the wrong bash test being used. See https://github.com/ACCESS-NRI/model-config-tests/pull/56/commits/0b7b943fed9a3d819ad0379a34bedaa6df7799c3 (for PR CI) and https://github.com/ACCESS-NRI/model-config-tests/pull/56/commits/b71a244e2942cad2407a142d8369df906cd6056c (for Scheduled CI). See [Failed Comment](https://github.com/ACCESS-NRI/access-esm1.5-configs/actions/runs/10609553828/job/29405862531?pr=86#step:3:1).
- The pipeline was allowing merging when the version hadn't been updated properly. This was because it was comparing release (`'1.0'`) against dev (`''`), seeing that the versions were different, and allowing merging. We now check for `''`, not just `null`. See https://github.com/ACCESS-NRI/model-config-tests/pull/56/commits/89d6d6ce48c042fa5cd90972be244e10ef35b1f4 and https://github.com/ACCESS-NRI/model-config-tests/pull/56/commits/6a36a4cdecb9974232363eafefa9110e929e244c. See [Workflow Log Annotation](https://github.com/ACCESS-NRI/access-esm1.5-configs/actions/runs/10609553828/job/29405770802?pr=86#step:4:13).

And fixes up some variables in comments:
- We were using `${{ needs.repro-test.outputs.artifact-url }}` but that wasn't actually an output to that job, so it would be the empty string. Added it in https://github.com/ACCESS-NRI/model-config-tests/pull/56/commits/3ddef0d587bdcc4b8097e7f17b84a4d74812be1d. See end of PR comment https://github.com/ACCESS-NRI/access-esm1.5-configs/pull/86#issuecomment-2316792404
- Simplified the comment and issue bodies template variables in https://github.com/ACCESS-NRI/model-config-tests/pull/56/commits/39c2edf9f257b7c52fb06916d9021335e5956063 and https://github.com/ACCESS-NRI/model-config-tests/pull/56/commits/0bf1601028e04cdb623f5603cc0bac52f3d72977.

Linking failed PRs https://github.com/ACCESS-NRI/access-esm1.5-configs/pull/86 and https://github.com/ACCESS-NRI/access-esm1.5-configs/pull/87
Closes #57 
