### PR TITLE
Dispatchable Workflow for Service User Config Inputs Copying

### DIFF
--- a/.github/workflows/inputs-remote-copy.yml
+++ b/.github/workflows/inputs-remote-copy.yml
@@ -25,6 +25,7 @@ on:
         type: string
         required: true
         # Default to no write for everyone except tm70_ci
+        # TODO: This default will probably not work for other `remote-environment`s
         default: >-
           u::rwx,
           u:tm70_ci:rwx,

--- a/.github/workflows/inputs-remote-copy.yml
+++ b/.github/workflows/inputs-remote-copy.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Verify Remote Target
         run: |
-          if [[ "${{ contains(inputs.target, '/g/data/vk83/configurations/inputs') }}" == "true" ]]; then
+          if [[ "${{ contains(inputs.target, vars.CONFIGS_INPUT_DIR) }}" == "true" ]]; then
             echo "::error::Remote target '${{ inputs.target }}' doesn't look like a configurations input directory."
             exit 1
           fi

--- a/.github/workflows/inputs-remote-copy.yml
+++ b/.github/workflows/inputs-remote-copy.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Verify Remote Target
         run: |
-          if [[ "${{ contains(inputs.target, vars.CONFIGS_INPUT_DIR) }}" == "true" ]]; then
+          if [[ "${{ startsWith(inputs.target, vars.CONFIGS_INPUT_DIR) }}" == "true" ]]; then
             echo "::error::Remote target '${{ inputs.target }}' doesn't look like a configurations input directory."
             exit 1
           fi

--- a/.github/workflows/inputs-remote-copy.yml
+++ b/.github/workflows/inputs-remote-copy.yml
@@ -1,0 +1,89 @@
+name: Config Inputs Remote Copy
+run-name: "${{ inputs.remote-environment }} Config Input Copy to ${{ inputs.target }}"
+on:
+  workflow_dispatch:
+    inputs:
+      remote-environment:
+        type: choice
+        required: true
+        description: The Github Environment for the given remote
+        options:
+          - Gadi
+      source:
+        type: string
+        required: true
+        description: Remote absolute path to configuration input file/folder
+      target:
+        type: string
+        required: true
+        description: Remote absolute path for the copied configuration input file/folder
+      overwrite-target:
+        type: boolean
+        required: true
+        description: Overwrite the remote target if it already exists
+      target-acl-spec:
+        type: string
+        required: true
+        # Default to no write for everyone except tm70_ci
+        default: >-
+          u::rwx,
+          u:tm70_ci:rwx,
+          g::r-x,
+          m::rwx,
+          o::---,
+          d:u::rwx,
+          d:u:tm70_ci:rwx,
+          d:g::r-x,
+          d:m::rwx,
+          d:o::---
+        description: ACL spec to be passed to `setfacl -m` for the given target
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log inputs
+        run: |
+          echo ""::notice::Copy on ${{ inputs.remote-environment }} from '${{ inputs.source }}' to '${{ inputs.target }}' with ACLs '${{ inputs.target-acl-spec }}'"
+          echo "::${{ inputs.overwrite-target && 'warning' || 'notice' }}::This operation ${{ inputs.overwrite-target && 'WILL' || 'will not' }} overwrite ${{ inputs.target }}"
+
+      - name: Verify Remote Target
+        run: |
+          if [[ "${{ contains(inputs.target, '/g/data/vk83/configurations/inputs') }}" == "true" ]]; then
+            echo "::error::Remote target '${{ inputs.target }}' doesn't look like a configurations input directory."
+            exit 1
+          fi
+
+      - name: Verify Valid ACL Spec
+        if: inputs.target-acl-spec != ''
+        env:
+          TEST_DIR: ./test
+        run: |
+          mkdir ${{ env.TEST_DIR }}
+          setfacl --test --recursive --modify "${{ inputs.target-acl-spec }}" ${{ env.TEST_DIR }}
+
+  remote:
+    name: Remote
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.remote-environment }}
+    steps:
+      - name: Setup SSH
+        id: ssh
+        uses: access-nri/actions/.github/actions/setup-ssh@main
+        with:
+          private-key: ${{ secrets.SSH_KEY }}
+          hosts: |
+            ${{ secrets.SSH_HOST }}
+            ${{ secrets.SSH_HOST_DATA }}
+
+      - name: Rsync Source to Target
+        run: |
+          rsync --recursive --verbose -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
+            ${{ ! inputs.overwrite-target && '--ignore-existing' || '--update' }} \
+            '${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ inputs.source }}' \
+            '${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ inputs.target }}'
+
+      - name: Set ACLs on Target
+        if: inputs.target-acl-spec != ''
+        run: |
+          setfacl --recursive --modify "${{ inputs.target-acl-spec }}" ${{ inputs.target }}

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ The `.github` directory contains many different workflows and actions. This sect
 
 `CI.yml` and `CD.yml` are used to test, package and upload the `model-config-tests` package that is used by `model-configs`-style repositories across the ACCESS-NRI. These are the only workflows that run on this repository. The others are reusable workflows called by `model-configs`-style repositories, among others.
 
+### Dispatchable CI
+
+The `inputs-remote-copy.yml` dispatchable workflow allows the copying of model configuration input files/folders on the target environment (such as Gadi) as our service user, and optionally set ACLs.
+
 ### Reusable CI
 
 The `config-*.yml`, `generate-checksums.yml` and `test-repro.yml` workflows are called by `model-configs`-style repositories to test model configurations. They are stored in this repository to allow a central place to update generic CI used by all model configuration repositories.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The `.github` directory contains many different workflows and actions. This sect
 
 ### Dispatchable CI
 
-The `inputs-remote-copy.yml` dispatchable workflow allows the copying of model configuration input files/folders on the target environment (such as Gadi) as our service user, and optionally set ACLs.
+The `inputs-remote-copy.yml` dispatchable workflow allows the copying of model configuration input files/folders on the target environment (such as Gadi) as our service user. ACLs are set by default to only allow access to the service user, but this can be overridden by specifying `target-acl-spec`.
 
 ### Reusable CI
 


### PR DESCRIPTION
## Background

This PR adds a new user-dispatchable workflow for the moving of configuration input files across the same remote host as a service user. This is useful for allowing `/g/data/vk83` to remain as a kind of human-free-zone when it comes to important files.

## Questions for Reviewers

* Is the given default `target-acl-spec` correct?

## The PR 

In this PR:
- **Add new inputs-remote-copy dispatchable workflow**
- **README.md: Add info on inputs-remote-copy.yml**

Repository Settings Modified:
- Added `Gadi` GitHub Environment for access to remote `Gadi`

Closes ACCESS-NRI/model-config-inputs#1
