### PR TITLE
Add Optional Additional Artifact Contents

### DIFF
--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -13,6 +13,26 @@ on:
   #     - doc/**
   #     - .*
   #     - README.md
+    inputs:
+      additional-artifact-content-paths:
+        type: string
+        required: false
+        # For example, the value of 'checksum' will expand to something like
+        # '/scratch/tm70/repro-ci/experiments/MODEL-configs/dev-CONFIG/checksum'
+        # on the remote.
+        description: |
+          Newline-separated paths for inclusion in the release artifact.
+          Note that all paths given have 'env.EXPERIMENT_LOCATION/' prepended.
+    outputs:
+      repro-ci-artifact-name:
+        value: ${{ jobs.repro-ci.outputs.artifact-name }}
+        description: Name of the repro-ci artifact
+      repro-ci-artifact-url:
+        value: ${{ jobs.repro-ci.outputs.artifact-url }}
+        description: URL to the repro-ci artifact
+      repro-ci-experiment-location:
+        value: ${{ jobs.repro-ci.outputs.experiment-location }}
+        description: Location of the experiment on the target environment
 jobs:
   commit-check:
     name: Commit Check
@@ -206,6 +226,7 @@ jobs:
       test-markers: ${{ needs.config.outputs.repro-markers }}
       model-config-tests-version: ${{ needs.config.outputs.repro-model-config-tests-version }}
       payu-version: ${{ needs.config.outputs.repro-payu-version }}
+      additional-artifact-content-paths: ${{ inputs.additional-artifact-content-paths }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -46,7 +46,7 @@ on:
         value: ${{ jobs.repro.outputs.experiment-location }}
         description: Location of the experiment on the target environment
 env:
-  TEST_OUTPUT_LOCAL_LOCATION: /opt/test-output
+  ARTIFACT_LOCAL_LOCATION: /opt/artifact
 jobs:
   repro:
     # NOTE: A lot of these `vars` and `secrets` are not found in this repository. Instead, they are inherited
@@ -148,17 +148,20 @@ jobs:
         run: |
           rsync --recursive --verbose -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
             '${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.EXPERIMENT_LOCATION }}/checksum' \
-            ${{ env.TEST_OUTPUT_LOCAL_LOCATION }}
+            ${{ env.ARTIFACT_LOCAL_LOCATION }}
 
       - name: Copy Back Additional Artifact Content
         if: inputs.additional-artifact-content-paths != ''
+        # For each of the additional artifact content paths, rsync the data
+        # from the target into our runner for upload as an artifact
         run: |
-          FIXME: Verify that this works!
-          for path in ${{ inputs.additional-artifact-content-paths }}; do
-            rsync --recursive --verbose -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
-              "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.EXPERIMENT_LOCATION }}/$path" \
-              ${{ env.TEST_OUTPUT_LOCAL_LOCATION }}
-          done
+          while IFS= read -r content_path; do
+            if [[ -n "$content_path" ]]; then
+              rsync --recursive --verbose -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
+                "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.EXPERIMENT_LOCATION }}/$content_path" \
+                ${{ env.ARTIFACT_LOCAL_LOCATION }}
+            fi
+          done <<< "${{ inputs.additional-artifact-content-paths }}"
 
       - name: Generate Test Output Artifact Name
         id: artifact
@@ -170,4 +173,4 @@ jobs:
         with:
           name: ${{ steps.artifact.outputs.name }}
           if-no-files-found: error
-          path: ${{ env.TEST_OUTPUT_LOCAL_LOCATION }}
+          path: ${{ env.ARTIFACT_LOCAL_LOCATION }}

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -157,8 +157,8 @@ jobs:
         run: |
           while IFS= read -r content_path; do
             if [[ -n "$content_path" ]]; then
-              rsync --recursive --verbose -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
-                "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.EXPERIMENT_LOCATION }}/$content_path" \
+              rsync --recursive --relative --verbose -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
+                "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.EXPERIMENT_LOCATION }}/./$content_path" \
                 ${{ env.ARTIFACT_LOCAL_LOCATION }}
             fi
           done <<< "${{ inputs.additional-artifact-content-paths }}"

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -26,6 +26,15 @@ on:
         type: string
         required: true
         description: The payu module version used to create test virtual environment
+      additional-artifact-content-paths:
+        type: string
+        required: false
+        # For example, the value of 'checksum' will expand to something like
+        # '/scratch/tm70/repro-ci/experiments/MODEL-configs/dev-CONFIG/checksum'
+        # on the remote.
+        description: |
+          Newline-separated paths for inclusion in the release artifact.
+          Note that all paths given have 'env.EXPERIMENT_LOCATION/' prepended.
     outputs:
       artifact-name:
         value: ${{ jobs.repro.outputs.artifact-name }}
@@ -137,9 +146,19 @@ jobs:
 
       - name: Copy Back Checksums and Test Report
         run: |
-          rsync --recursive -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
-              '${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.EXPERIMENT_LOCATION }}/checksum' \
+          rsync --recursive --verbose -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
+            '${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.EXPERIMENT_LOCATION }}/checksum' \
+            ${{ env.TEST_OUTPUT_LOCAL_LOCATION }}
+
+      - name: Copy Back Additional Artifact Content
+        if: inputs.additional-artifact-content-paths != ''
+        run: |
+          FIXME: Verify that this works!
+          for path in ${{ inputs.additional-artifact-content-paths }}; do
+            rsync --recursive --verbose -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
+              "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.EXPERIMENT_LOCATION }}/$path" \
               ${{ env.TEST_OUTPUT_LOCAL_LOCATION }}
+          done
 
       - name: Generate Test Output Artifact Name
         id: artifact


### PR DESCRIPTION
## Background

This PR allows the option of adding additional paths from the repro-ci experiment run to the artifact. Used in https://github.com/ACCESS-NRI/access-om3-configs/pull/122

## Testing

- The rsync steps were tested and verified on my own organisation: https://github.com/codegat-test-org/test/actions/runs/10896252883/job/30235753417 with the [call.yml](https://github.com/codegat-test-org/test/blob/2af736280b24aad7798c3f356e16afaa6d2a6a6b/.github/workflows/call.yml) and [test.yml](https://github.com/codegat-test-org/test/blob/2af736280b24aad7798c3f356e16afaa6d2a6a6b/.github/workflows/test.yml) files

## The PR

In this PR:

- config-pr-1-ci.yml: Added new additional-artifact-content-paths input, artifact and experiment outputs
- test-repro.yml: Added optional input for additional artifact contents, rsync additional artifact contents

Closes #66
