### PR TITLE
Run CI on `dev-*` Branches

### DIFF
--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -54,12 +54,8 @@ jobs:
 
   branch-check:
     name: PR Source Branch Check
-    # This check is used as a precursor to any repro-ci checks - which are only fired
-    # on dev-* -> release-* PRs.
     # This check is run to confirm that the source branch is of the form `dev-<config>`
-    # and the target branch is of the form `release-<config>`. We are being especially
-    # concerned with branch names because deployment to GitHub Environments can only
-    # be done on source branches with a certain pattern. See ACCESS-NRI/access-om2-configs#20.
+    # and the target branch is of the form `release-<config>`.
     if: needs.commit-check.outputs.authorship != vars.GH_ACTIONS_BOT_GIT_USER_NAME && startsWith(github.base_ref, 'release-') && startsWith(github.head_ref, 'dev-')
     needs:
       - commit-check
@@ -71,7 +67,15 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Compare Source and Target Config Names
+      - name: "release-* PR: Check source is dev-*"
+        # In a PR into target 'release-*', make sure the source is 'dev-*'
+        run: |
+          if [[ "${{ startsWith(github.head_ref, 'dev-') }}" != "true" ]]; then
+            echo "::error::For pull requests into `release-*` branches, the source branch should be `dev-*`."
+            exit 1
+          fi
+
+      - name: "release-* PR: Compare Source and Target Config Names"
         # In this step, we cut the 'dev-' and 'release-' to compare config names directly.
         run: |
           source=$(cut --delimiter '-' --field 2- <<< "${{ github.head_ref }}")
@@ -102,11 +106,11 @@ jobs:
       repro-markers: ${{ steps.repro-config.outputs.markers }}
       repro-payu-version: ${{ steps.repro-config.outputs.payu-version }}
       repro-model-config-tests-version: ${{ steps.repro-config.outputs.model-config-tests-version }}
-      compared-config-tag: ${{ steps.compared.outputs.tag }}
+      compared-config-ref: ${{ steps.compared.outputs.ref }}
     steps:
       - name: Checkout main
         # We fetch the repository history because in `steps.compared` we
-        # attempt to get the last config tag.
+        # attempt to get the last config tag for 'release-*' branches.
         uses: actions/checkout@v4
         with:
           ref: main
@@ -140,14 +144,19 @@ jobs:
       - name: Get Config Tag to Compare Against
         id: compared
         # We checkout the base branch (the branch that will be merged into)
-        # to get the last tagged configuration checksums.
-        # We could also just take the HEAD of the base_ref, which would give
-        # the same result, but tags are human readable.
+        # to get the last tagged configuration checksums for 'release-*' branches.
         # In the case where there is no tag, `tag` will be an empty string,
         # which is handled later.
+        # For non-'release-*' branches, just get the HEAD of the base branch.
         run: |
           git checkout ${{ github.base_ref }}
-          echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+          if [[ "${{ startsWith(github.head_ref, 'release-') }}" == "true" ]]; then
+            ref=$(git describe --tags --abbrev=0)
+          else
+            ref=${{ github.event.pull_request.head.sha }}
+          fi
+          echo "Will compare against ref '$ref'"
+          echo "ref=$ref" >> $GITHUB_OUTPUT
 
   qa-ci:
     # Run quick, non-HPC tests on the runner.
@@ -216,13 +225,16 @@ jobs:
       - commit-check
       - branch-check
       - config
-    if: needs.commit-check.outputs.authorship != vars.GH_ACTIONS_BOT_GIT_USER_NAME && needs.branch-check.result == 'success'
+    if: |
+      always() &&
+      needs.commit-check.outputs.authorship != vars.GH_ACTIONS_BOT_GIT_USER_NAME &&
+      needs.branch-check.result != 'failed'
     uses: access-nri/model-config-tests/.github/workflows/test-repro.yml@main
     with:
       # FIXME: Make the environment name an input of some kind - what if we deploy to a different supercomputer?
       environment-name: Gadi
       config-ref: ${{ github.head_ref }}
-      compared-config-ref: ${{ needs.config.outputs.compared-config-tag }}
+      compared-config-ref: ${{ needs.config.outputs.compared-config-ref }}
       test-markers: ${{ needs.config.outputs.repro-markers }}
       model-config-tests-version: ${{ needs.config.outputs.repro-model-config-tests-version }}
       payu-version: ${{ needs.config.outputs.repro-payu-version }}
@@ -279,9 +291,10 @@ jobs:
   bump-check:
     name: Version Bump Check
     # Check that the `.version` in the metadata.yaml has been modified in
-    # this PR.
+    # this PR. We only care about the versioning if this is a dev-* -> release-* PR.
     needs:
       - repro-ci
+    if: startsWith(github.base_ref, 'release-')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR Target
@@ -322,15 +335,15 @@ jobs:
     permissions:
       pull-requests: write
     env:
-      COMPARED_TAG: ${{ needs.config.outputs.compared-config-tag }}
-      COMPARED_CHECKSUM_STRING: ${{ needs.config.outputs.compared-config-tag != '' && format('The checksums compared against are found here {0}/{1}/tree/{2}/testing/checksum', github.server_url, github.repository, needs.config.outputs.compared-config-tag) || '' }}
+      COMPARED_REF: ${{ needs.config.outputs.compared-config-ref }}
+      COMPARED_CHECKSUM_STRING: ${{ needs.config.outputs.compared-config-ref != '' && format('The checksums compared against are found here {0}/{1}/tree/{2}/testing/checksum', github.server_url, github.repository, needs.config.outputs.compared-config-ref) || '' }}
     steps:
       - name: Successful Repro Comment
         if: needs.check-checksum.outputs.result == 'pass'
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
-            :white_check_mark: The Bitwise Reproducibility check succeeded when comparing against `${{ env.COMPARED_TAG }}` :white_check_mark:
+            :white_check_mark: The Bitwise Reproducibility check succeeded when comparing against `${{ env.COMPARED_REF }}` :white_check_mark:
             You must bump the minor version of this configuration - to bump the version, comment `!bump minor` or modify the `version` in `metadata.yaml`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
 
             <details>
@@ -349,7 +362,7 @@ jobs:
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
-            :x: The Bitwise Reproducibility check failed ${{ env.COMPARED_TAG != '' && format('when comparing against `{0}`', env.COMPARED_TAG) || 'as there is no earlier checksum to compare against' }} :x:
+            :x: The Bitwise Reproducibility check failed ${{ env.COMPARED_REF != '' && format('when comparing against `{0}`', env.COMPARED_REF) || 'as there is no earlier checksum to compare against' }} :x:
             You must bump the major version of this configuration - to bump the version, comment `!bump major`or modify the `version` in `metadata.yaml`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
 
             <details>


### PR DESCRIPTION
This PR allows repro checks to be run on PRs into `dev-*` branches, rather than just `release-*` branches. 

In this PR:
- Remove requirement of `base_ref` being `release-*` in a bunch of places. 
- Rework the ref given to `compared-config-ref` in `test-repro.yml` so it's not just tags.

Closes #38
