### PR TITLE
`!test` Comment Command

### DIFF
--- a/.github/workflows/config-comment-repro.yml
+++ b/.github/workflows/config-comment-repro.yml
@@ -1,0 +1,201 @@
+name: 'Comment Command: !repro'
+run-name: '!repro on ${{ github.repository }}'
+on:
+  workflow_call:
+  # Triggered by:
+  # on:
+  #   issue_comment:
+  #     - edited
+  #     - created
+env:
+  USAGE: '!repro [against COMMITISH]'
+jobs:
+  ci-config:
+    name: Read CI Testing Configuration
+    runs-on: ubuntu-latest
+    outputs:
+      markers: ${{ steps.repro-config.outputs.markers }}
+      payu-version: ${{ steps.repro-config.outputs.payu-version }}
+      model-config-tests-version: ${{ steps.repro-config.outputs.model-config-tests-version }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Validate `config/ci.json`
+        uses: access-nri/schema/.github/actions/validate-with-schema@main
+        with:
+          # As with a lot of the `vars`/`secrets` in this repo, this will be defined in the caller repo
+          schema-version: ${{ vars.CI_JSON_SCHEMA_VERSION }}
+          meta-schema-version: draft-2020-12
+          schema-location: au.org.access-nri/model/configuration/ci
+          data-location: config/ci.json
+
+      - name: Get base branch for PR
+        id: base
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr checkout ${{ github.event.issue.number }}
+          echo "branch=$(gh pr view --json baseRefName --jq '.baseRefName')"
+
+      - name: Read reproducibility tests config
+        id: repro-config
+        uses: access-nri/model-config-tests/.github/actions/parse-ci-config@main
+        with:
+          check: reproducibility
+          branch-or-tag: ${{ steps.base.outputs.branch }}
+          config-filepath: "config/ci.json"
+
+  prepare-command:
+    name: Prepare Command
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    outputs:
+      config-hash: ${{ steps.pr.outputs.hash }}
+      config-ref: ${{ steps.pr.outputs.ref }}
+      compared-config-hash: ${{ steps.compared.outputs.hash }}
+      compared-config-ref: ${{ steps.compared.outputs.ref }}
+      # TODO: Make this an input to the command when we start deploying to multiple targets
+      environment-name: Gadi
+    permissions:
+      pull-requests: write
+    steps:
+      - name: React to '!repro'
+        uses: access-nri/actions/.github/actions/react-to-comment@main
+        with:
+          reaction: rocket
+          token: ${{ github.token }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Get config ref from PR comment
+        id: pr
+        run: |
+          gh pr checkout ${{ github.event.issue.number }}
+          echo "hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "ref=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Get compared config ref from PR comment
+        id: compared
+        run: |
+          command='${{ github.event.issue.comment.body }}'
+          read -ra command_tokens <<< "$command"
+          # Remove the leading '!repro'
+          read -ra command_args <<< "${command_tokens[@]:1}"
+
+          # Set up a default ref
+          gh repo checkout ${{ github.event.issue.number }}
+          ref=$(gh pr view --json baseRefName --jq '.baseRefName')
+          hash=$(git merge-base --fork-point "$ref")
+
+          is_explicit_comparison=false
+
+          # Go through all the tokens...
+          for token in "${command_args[@]}"; do
+            if [[ "$token" == "against" ]]; then
+              is_explicit_comparison=true
+              continue
+            fi
+
+            if [[ "$is_explicit_comparison" == "true" ]]; then
+              hash=$token
+              is_explicit_comparison=false
+            fi
+          done
+
+          # Do some error checking...
+          if [[ "$is_explicit_comparison" == "true" ]]; then
+            echo "::error::Used 'against' without specifying a commit hash. Usage: ${{ env.USAGE }}"
+            exit 1
+          fi
+
+          echo "hash=$hash" >> $GITHUB_OUTPUT
+          echo "ref=$ref" >> $GITHUB_OUTPUT
+
+  repro:
+    name: Compare ${{ needs.prepare-command.outputs.config-ref }} against ${{ needs.prepare-command.outputs.compared-config-ref }}
+    needs:
+      - prepare-command
+      - ci-config
+    uses: access-nri/model-config-tests/.github/workflows/test-repro.yml@main
+    with:
+      config-ref: ${{ needs.prepare-command.outputs.config-hash }}
+      compared-config-ref: ${{ needs.prepare-command.outputs.compared-config-hash }}
+      environment-name: ${{ needs.prepare-command.outputs.environment-name }}
+      payu-version: ${{ needs.ci-config.outputs.payu-version }}
+      model-config-tests-version: ${{ needs.ci-config.outputs.model-config-tests-version }}
+      test-markers: ${{ needs.ci-config.outputs.markers }}
+    secrets: inherit
+    permissions:
+      contents: write
+
+  check-repro:
+    # Parse the test report and return pass/fail result
+    name: Results
+    needs:
+      - prepare-command
+      - repro
+    runs-on: ubuntu-latest
+    env:
+      TESTING_LOCAL_LOCATION: /opt/testing
+    permissions:
+      checks: write
+    steps:
+      - name: Download Newly Created Checksum
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.repro.outputs.artifact-name }}
+          path: ${{ env.TESTING_LOCAL_LOCATION }}
+
+      - name: Parse Test Report
+        id: tests
+        uses: EnricoMi/publish-unit-test-result-action/composite@e780361cd1fc1b1a170624547b3ffda64787d365  #v2.12.0
+        with:
+          files: ${{ env.TESTING_LOCAL_LOCATION }}/checksum/test_report.xml
+          comment_mode: off
+          check_run: true
+          compare_to_earlier_commit: false
+          report_individual_runs: true
+          report_suite_logs: any
+
+      - name: Repro results
+        id: results
+        run: |
+          echo "check-url=${{ fromJson(steps.tests.outputs.json).check_url }}" >> $GITHUB_OUTPUT
+
+          if (( ${{ fromJson(steps.tests.outputs.json).stats.tests_fail }} > 0 )); then
+            echo "result=fail" >> $GITHUB_OUTPUT
+          else
+            echo "result=pass" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Comment result
+        env:
+          RESULT: |-
+            ${{ steps.results.outputs.result == 'pass' && ':white_check_mark: The Bitwise Reproducibility Check Succeeded :white_check_mark:' || ':x: The Bitwise Reproducibility Check Failed :x:' }}
+          COMPARED_REF: ${{ needs.prepare-command.outputs.compared-config-ref != '' && format('(on branch `{0}`)', needs.prepare-command.outputs.compared-config-ref) || '' }}
+        uses: access-nri/actions/.github/actions/pr-comment@main
+        with:
+          comment: |
+            ${{ env.RESULT }}
+            When comparing:
+
+            - `${{ needs.prepare-command.outputs.config-hash }}` (on branch `${{ needs.prepare-command.outputs.config-ref }}`), against
+            - `${{ needs.prepare-command.outputs.compared-config-hash }}` ${{ env.COMPARED_REF }}
+
+            <details>
+            <summary> Further information</summary>
+
+            The experiment can be found on Gadi at `${{ needs.repro.outputs.experiment-location }}`, and the test results at ${{ steps.results.outputs.check-run-url }}.
+
+            The checksums generated by this `!repro` command are found in the `testing/checksum` directory of ${{ needs.repro.outputs.artifact-url }}.
+
+            The checksums compared against are found here ${{ github.server_url }}/${{ github.repository }}/tree/${{ needs.prepare-command.outputs.compared-config-hash }}/testing/checksum
+
+            </details>

--- a/.github/workflows/config-comment-repro.yml
+++ b/.github/workflows/config-comment-repro.yml
@@ -174,7 +174,7 @@ jobs:
         id: tests
         uses: EnricoMi/publish-unit-test-result-action/composite@e780361cd1fc1b1a170624547b3ffda64787d365  #v2.12.0
         with:
-          files: ${{ env.TESTING_LOCAL_LOCATION }}/checksum/test_report.xml
+          files: ${{ env.TESTING_LOCAL_LOCATION }}/testing/checksum/test_report.xml
           comment_mode: off
           check_run: true
           compare_to_earlier_commit: false
@@ -252,9 +252,10 @@ jobs:
           name: ${{ needs.repro.outputs.artifact-name }}
           path: ${{ env.ARTIFACT_LOCAL_LOCATION }}
 
-      - name: Update checksum files
+      - name: Update files
+        # This will copy checksums, as well as any other files specified by inputs.additional-artifact-content-paths
         run: |
-          cp --recursive --verbose ${{ env.ARTIFACT_LOCAL_LOCATION }}/*/* testing
+          cp --recursive --verbose ${{ env.ARTIFACT_LOCAL_LOCATION }} .
 
       - name: Import Commit-Signing Key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
@@ -270,5 +271,5 @@ jobs:
 
       - name: Commit and Push Updates
         run: |
-          git commit -am "Updated checksums as part of ${{ env.RUN_URL }}"
+          git commit -am "Updated files as part of ${{ env.RUN_URL }}"
           git push

--- a/.github/workflows/config-comment-repro.yml
+++ b/.github/workflows/config-comment-repro.yml
@@ -9,6 +9,7 @@ on:
   #     - created
 env:
   USAGE: '!repro [commit] [compare COMMITISH]'
+  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 jobs:
   ci-config:
     name: Read CI Testing Configuration
@@ -254,11 +255,8 @@ jobs:
 
       - name: Checkout Associated PR ${{ github.event.issue.number }}
         # Since the trigger for this workflow was on.issue_comment, we need
-        # to do a bit more wrangling to checkout the pull request and get the branch name
-        id: pr
-        run: |
-          gh pr checkout ${{ github.event.issue.number }}
-          echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
+        # to do a bit more wrangling to checkout the pull request
+        run: gh pr checkout ${{ github.event.issue.number }}
 
       - name: Download Newly Created Checksum
         uses: actions/download-artifact@v4
@@ -284,5 +282,5 @@ jobs:
 
       - name: Commit and Push Updates
         run: |
-          git commit -am "Updated checksums and bumped version to ${{ needs.bump-version.outputs.after }} as part of ${{ env.RUN_URL }}"
+          git commit -am "Updated checksums as part of ${{ env.RUN_URL }}"
           git push

--- a/.github/workflows/config-comment-repro.yml
+++ b/.github/workflows/config-comment-repro.yml
@@ -2,6 +2,16 @@ name: 'Comment Command: !repro'
 run-name: '!repro on ${{ github.repository }}'
 on:
   workflow_call:
+    inputs:
+      additional-artifact-content-paths:
+        type: string
+        required: false
+        # For example, the value of 'checksum' will expand to something like
+        # '/scratch/tm70/repro-ci/experiments/MODEL-configs/dev-CONFIG/checksum'
+        # on the remote.
+        description: |
+          Newline-separated paths for inclusion in the release artifact.
+          Note that all paths given have 'env.EXPERIMENT_LOCATION/' prepended.
   # Triggered by:
   # on:
   #   issue_comment:
@@ -160,6 +170,7 @@ jobs:
       payu-version: ${{ needs.ci-config.outputs.payu-version }}
       model-config-tests-version: ${{ needs.ci-config.outputs.model-config-tests-version }}
       test-markers: ${{ needs.ci-config.outputs.markers }}
+      additional-artifact-content-paths: ${{ inputs.additional-artifact-content-paths }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/config-comment-repro.yml
+++ b/.github/workflows/config-comment-repro.yml
@@ -18,7 +18,7 @@ on:
   #     - edited
   #     - created
 env:
-  USAGE: '!repro [commit] [compare COMMITISH]'
+  USAGE: '!test repro [commit]'
   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 jobs:
   ci-config:
@@ -98,39 +98,15 @@ jobs:
           echo "hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "ref=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Get compared config ref from PR comment
+      - name: Get compared config ref
         id: compared
+        # Set up a default ref
         run: |
-          command='${{ github.event.issue.comment.body }}'
-          read -ra command_tokens <<< "$command"
-          # Remove the leading '!repro'
-          read -ra command_args <<< "${command_tokens[@]:1}"
-
-          # Set up a default ref
           gh repo checkout ${{ github.event.issue.number }}
           ref=$(gh pr view --json baseRefName --jq '.baseRefName')
           hash=$(git merge-base --fork-point "$ref")
 
-          is_explicit_comparison=false
-
-          # Go through all the tokens...
-          for token in "${command_args[@]}"; do
-            if [[ "$token" == "compare" ]]; then
-              is_explicit_comparison=true
-              continue
-            fi
-
-            if [[ "$is_explicit_comparison" == "true" ]]; then
-              hash=$token
-              is_explicit_comparison=false
-            fi
-          done
-
-          # Do some error checking...
-          if [[ "$is_explicit_comparison" == "true" ]]; then
-            echo "::error::Used 'compare' without specifying a commit hash. Usage: ${{ env.USAGE }}"
-            exit 1
-          fi
+          echo "Using $hash (on $ref)"
 
           echo "hash=$hash" >> $GITHUB_OUTPUT
           echo "ref=$ref" >> $GITHUB_OUTPUT
@@ -139,6 +115,7 @@ jobs:
         id: commit
         # Determine whether the commenter can actually commit something to the repo if they write 'commit'
         # by getting their repo permissions.
+        # TODO: The permissions-checking section seems ripe for turning into an action!
         run: |
           if [[ "${{ contains(github.event.comment.body, 'commit') }}" == "false" ]]; then
             echo "'commit' option not given"

--- a/.github/workflows/config-comment-repro.yml
+++ b/.github/workflows/config-comment-repro.yml
@@ -8,7 +8,7 @@ on:
   #     - edited
   #     - created
 env:
-  USAGE: '!repro [against COMMITISH]'
+  USAGE: '!repro [compare COMMITISH]'
 jobs:
   ci-config:
     name: Read CI Testing Configuration
@@ -98,7 +98,7 @@ jobs:
 
           # Go through all the tokens...
           for token in "${command_args[@]}"; do
-            if [[ "$token" == "against" ]]; then
+            if [[ "$token" == "compare" ]]; then
               is_explicit_comparison=true
               continue
             fi
@@ -111,7 +111,7 @@ jobs:
 
           # Do some error checking...
           if [[ "$is_explicit_comparison" == "true" ]]; then
-            echo "::error::Used 'against' without specifying a commit hash. Usage: ${{ env.USAGE }}"
+            echo "::error::Used 'compare' without specifying a commit hash. Usage: ${{ env.USAGE }}"
             exit 1
           fi
 

--- a/.github/workflows/config-comment-repro.yml
+++ b/.github/workflows/config-comment-repro.yml
@@ -8,7 +8,7 @@ on:
   #     - edited
   #     - created
 env:
-  USAGE: '!repro [compare COMMITISH]'
+  USAGE: '!repro [commit] [compare COMMITISH]'
 jobs:
   ci-config:
     name: Read CI Testing Configuration
@@ -54,10 +54,16 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     outputs:
+      # the git hash of the configuration being tested
       config-hash: ${{ steps.pr.outputs.hash }}
+      # the git ref (branch or tag) of the configuration being tested
       config-ref: ${{ steps.pr.outputs.ref }}
+      # the git hash of the configuration being compared against
       compared-config-hash: ${{ steps.compared.outputs.hash }}
+      # the git ref (branch or tag) of the configuration being compared against
       compared-config-ref: ${{ steps.compared.outputs.ref }}
+      # whether the commenter can commit to the repo (either 'true', 'false' or '' (when no 'commit' option given))
+      has-commit-permission: ${{ steps.commit.outputs.permission }}
       # TODO: Make this an input to the command when we start deploying to multiple targets
       environment-name: Gadi
     permissions:
@@ -118,6 +124,28 @@ jobs:
           echo "hash=$hash" >> $GITHUB_OUTPUT
           echo "ref=$ref" >> $GITHUB_OUTPUT
 
+      - name: Determine whether to commit
+        id: commit
+        # Determine whether the commenter can actually commit something to the repo if they write 'commit'
+        # by getting their repo permissions.
+        run: |
+          if [[ "${{ contains(github.event.comment.body, 'commit') }}" == "false" ]]; then
+            echo "'commit' option not given"
+            exit 0
+          fi
+
+          commenter_permissions=$(gh api /
+              repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission
+              --jq '.permission'
+          )
+          if [[ "$commenter_permission" == "admin" || "$commenter_permission" == "write" ]]; then
+            echo "'commit' option given and commenter has at least write permission"
+            echo "permission=true" >> $GITHUB_OUTPUT
+          else
+            echo "'commit' option given but commenter does not have at least write permission"
+            echo "permission=false" >> $GITHUB_OUTPUT
+          fi
+
   repro:
     name: Compare ${{ needs.prepare-command.outputs.config-ref }} against ${{ needs.prepare-command.outputs.compared-config-ref }}
     needs:
@@ -177,9 +205,11 @@ jobs:
 
       - name: Comment result
         env:
+          COMPARED_REF: ${{ needs.prepare-command.outputs.compared-config-ref != '' && format('(on branch `{0}`)', needs.prepare-command.outputs.compared-config-ref) || '' }}
           RESULT: |-
             ${{ steps.results.outputs.result == 'pass' && ':white_check_mark: The Bitwise Reproducibility Check Succeeded :white_check_mark:' || ':x: The Bitwise Reproducibility Check Failed :x:' }}
-          COMPARED_REF: ${{ needs.prepare-command.outputs.compared-config-ref != '' && format('(on branch `{0}`)', needs.prepare-command.outputs.compared-config-ref) || '' }}
+          COMMIT_RESULT: |-
+            ${{ needs.prepare-command.outputs.has-commit-permission == 'true' && ':wrench: This result has been committed to this PR, if it differs from the current `HEAD`' || ':warning: This result is not being committed to this PR, as the commenter does not have `write` permissions' }}
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
@@ -188,6 +218,8 @@ jobs:
 
             - `${{ needs.prepare-command.outputs.config-hash }}` (on branch `${{ needs.prepare-command.outputs.config-ref }}`), against
             - `${{ needs.prepare-command.outputs.compared-config-hash }}` ${{ env.COMPARED_REF }}
+
+            ${{ needs.prepare-command.outputs.has-commit-permission != '' && env.COMMIT_RESULT || '' }}
 
             <details>
             <summary> Further information</summary>
@@ -199,3 +231,58 @@ jobs:
             The checksums compared against are found here ${{ github.server_url }}/${{ github.repository }}/tree/${{ needs.prepare-command.outputs.compared-config-hash }}/testing/checksum
 
             </details>
+
+  commit:
+    name: Commit Result
+    if: needs.prepare-command.outputs.has-commit-permission == 'true'
+    needs:
+      - prepare-command
+      - repro
+      - check-repro
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      ARTIFACT_LOCAL_LOCATION: /opt/artifact
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_COMMIT_CHECK_TOKEN }}
+
+      - name: Checkout Associated PR ${{ github.event.issue.number }}
+        # Since the trigger for this workflow was on.issue_comment, we need
+        # to do a bit more wrangling to checkout the pull request and get the branch name
+        id: pr
+        run: |
+          gh pr checkout ${{ github.event.issue.number }}
+          echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Download Newly Created Checksum
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.repro.outputs.artifact-name }}
+          path: ${{ env.ARTIFACT_LOCAL_LOCATION }}
+
+      - name: Update checksum files
+        run: |
+          cp --recursive --verbose ${{ env.ARTIFACT_LOCAL_LOCATION }}/*/* testing
+
+      - name: Import Commit-Signing Key
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
+        with:
+          gpg_private_key: ${{ secrets.GH_ACTIONS_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GH_ACTIONS_BOT_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_committer_name: ${{ vars.GH_ACTIONS_BOT_GIT_USER_NAME }}
+          git_committer_email: ${{ vars.GH_ACTIONS_BOT_GIT_USER_EMAIL }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+
+      - name: Commit and Push Updates
+        run: |
+          git commit -am "Updated checksums and bumped version to ${{ needs.bump-version.outputs.after }} as part of ${{ env.RUN_URL }}"
+          git push

--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Get test type
         id: test
         run: |
-          command="${{ github.event.issue.comment.body }}"
+          command="${{ github.event.comment.body }}"
           read -ra command_tokens <<< "$command"
           type_in_comment="${command_tokens[1]}"
           type_in_comment_valid=false
@@ -99,7 +99,7 @@ jobs:
           done
 
           if [[ "$type_in_comment_valid" == "false" ]]; then
-            echo "::error::The command '${{ github.event.issue.comment.body }}' doesn't have a valid TYPE. Was given '$type_in_command', but needed to be one of: ${{ env.USAGE_TYPES }}."
+            echo "::error::The command '${{ github.event.comment.body }}' doesn't have a valid TYPE. Was given '$type_in_command', but needed to be one of: ${{ env.USAGE_TYPES }}."
             exit 1
           fi
 

--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -12,8 +12,40 @@ env:
   USAGE_TYPES: repro
   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 jobs:
+  permission-check:
+    name: Permission Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine if commenter has permission to run the command
+        id: commenter
+        # TODO: The permissions-checking section seems ripe for turning into an action!
+        run: |
+          commenter_permissions=$(gh api \
+              repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission \
+              --jq '.permission'
+          )
+          if [[ "$commenter_permission" == "admin" || "$commenter_permission" == "write" ]]; then
+            echo "Commenter has at least write permission"
+            echo "permission=true" >> $GITHUB_OUTPUT
+          else
+            echo "Commenter does not have at least write permission"
+            echo "permission=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: React to '!test'
+        uses: access-nri/actions/.github/actions/react-to-comment@main
+        with:
+          reaction: ${{ steps.commenter.outputs.permission == 'true' && 'rocket' || 'confused' }}
+          token: ${{ github.token }}
+
+      - name: Fail if no permissions
+        if: steps.commenter.outputs.permission == 'false'
+        run: exit 1
+
   ci-config:
     name: Read CI Testing Configuration
+    needs:
+      - permission-check
     runs-on: ubuntu-latest
     outputs:
       markers: ${{ steps.repro-config.outputs.markers }}
@@ -52,32 +84,32 @@ jobs:
 
   prepare-command:
     name: Prepare Command
+    needs:
+      - permission-check
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
     outputs:
       test-type: ${{ steps.test.outputs.type }}
-      # the git hash of the configuration being tested
+      # the full git hash of the configuration being tested
       config-hash: ${{ steps.pr.outputs.hash }}
+      # the short git hash of the configuration being tested
+      config-short-hash: ${{ steps.pr.outputs.short-hash }}
       # the git ref (branch or tag) of the configuration being tested
       config-ref: ${{ steps.pr.outputs.ref }}
-      # the git hash of the configuration being compared against
+      # the full git hash of the configuration being compared against
       compared-config-hash: ${{ steps.compared.outputs.hash }}
+      # the short git hash of the configuration being compared against
+      compared-config-short-hash: ${{ steps.compared.outputs.short-hash }}
       # the git ref (branch or tag) of the configuration being compared against
       compared-config-ref: ${{ steps.compared.outputs.ref }}
       # whether the commenter can commit to the repo (either 'true', 'false' or '' (when no 'commit' option given))
-      has-commit-permission: ${{ steps.commit.outputs.permission }}
+      commit-requested: ${{ steps.commit.outputs.requested }}
       # TODO: Make this an input to the command when we start deploying to multiple targets
       environment-name: Gadi
     permissions:
       pull-requests: write
     steps:
-      - name: React to '!test'
-        uses: access-nri/actions/.github/actions/react-to-comment@main
-        with:
-          reaction: rocket
-          token: ${{ github.token }}
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -92,62 +124,55 @@ jobs:
           type_in_comment_valid=false
 
           for type in ${{ env.USAGE_TYPES }}; do
-            if [[ "$type_in_command" == "$type" ]]; then
+            if [[ "$type_in_comment" == "$type" ]]; then
               type_in_comment_valid=true
               break
             fi
           done
 
           if [[ "$type_in_comment_valid" == "false" ]]; then
+            echo "::error::Usage: ${{ env.USAGE }}"
             echo "::error::The command '${{ github.event.comment.body }}' doesn't have a valid TYPE. Was given '$type_in_command', but needed to be one of: ${{ env.USAGE_TYPES }}."
             exit 1
           fi
 
-          echo "type=$type_in_command" >> $GITHUB_OUTPUT
+          echo "type=$type_in_comment" >> $GITHUB_OUTPUT
 
       - name: Get config ref from PR comment
         id: pr
         run: |
           gh pr checkout ${{ github.event.issue.number }}
           echo "hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "short-hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "ref=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
 
       - name: Get compared config ref
         id: compared
         # Set up a default ref
+        # We need to do this roundabout way to get the source branch commit because
+        # We can't access github.base_ref as this trigger is on.issue_comment
         run: |
-          gh repo checkout ${{ github.event.issue.number }}
-          ref=$(gh pr view --json baseRefName --jq '.baseRefName')
-          hash=$(git merge-base --fork-point "$ref")
-
-          echo "Using $hash (on $ref)"
+          ref=$(gh pr view ${{ github.event.issue.number }} --json baseRefName --jq '.baseRefName')
+          echo "Using $ref"
+          hash=$(git show-branch --merge-base origin/$ref origin/${{ steps.pr.outputs.ref }})
+          short_hash=$(git rev-parse --short $hash)
+          echo "AKA $hash (shortened as $short_hash)"
 
           echo "hash=$hash" >> $GITHUB_OUTPUT
+          echo "short-hash=$short_hash" >> $GITHUB_OUTPUT
           echo "ref=$ref" >> $GITHUB_OUTPUT
 
       - name: Determine whether to commit
         id: commit
-        # Determine whether the commenter can actually commit something to the repo if they write 'commit'
-        # by getting their repo permissions.
-        # TODO: The permissions-checking section seems ripe for turning into an action!
+        # Determine whether the commenter wants to commit something to the repository
         run: |
           if [[ "${{ contains(github.event.comment.body, 'commit') }}" == "false" ]]; then
             echo "'commit' option not given"
-            exit 0
-          fi
-
-          commenter_permissions=$(gh api /
-              repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission
-              --jq '.permission'
-          )
-          if [[ "$commenter_permission" == "admin" || "$commenter_permission" == "write" ]]; then
-            echo "'commit' option given and commenter has at least write permission"
-            echo "permission=true" >> $GITHUB_OUTPUT
+            echo "requested=false" >> $GITHUB_OUTPUT
           else
-            echo "'commit' option given but commenter does not have at least write permission"
-            echo "permission=false" >> $GITHUB_OUTPUT
+            echo "'commit' option given"
+            echo "requested=true" >> $GITHUB_OUTPUT
           fi
-
   repro:
     name: Compare ${{ needs.prepare-command.outputs.config-ref }} against ${{ needs.prepare-command.outputs.compared-config-ref }}
     needs:
@@ -176,6 +201,7 @@ jobs:
     env:
       TESTING_LOCAL_LOCATION: /opt/testing
     permissions:
+      pull-requests: write
       checks: write
     steps:
       - name: Download Newly Created Checksum
@@ -186,7 +212,7 @@ jobs:
 
       - name: Parse Test Report
         id: tests
-        uses: EnricoMi/publish-unit-test-result-action/composite@e780361cd1fc1b1a170624547b3ffda64787d365  #v2.12.0
+        uses: EnricoMi/publish-unit-test-result-action/composite@82082dac68ad6a19d980f8ce817e108b9f496c2a  #v2.17.1
         with:
           files: ${{ env.TESTING_LOCAL_LOCATION }}/checksum/test_report.xml
           comment_mode: off
@@ -208,28 +234,28 @@ jobs:
 
       - name: Comment result
         env:
-          COMPARED_REF: ${{ needs.prepare-command.outputs.compared-config-ref != '' && format('(on branch `{0}`)', needs.prepare-command.outputs.compared-config-ref) || '' }}
           RESULT: |-
             ${{ steps.results.outputs.result == 'pass' && ':white_check_mark: The Bitwise Reproducibility Check Succeeded :white_check_mark:' || ':x: The Bitwise Reproducibility Check Failed :x:' }}
-          COMMIT_RESULT: |-
-            ${{ needs.prepare-command.outputs.has-commit-permission == 'true' && ':wrench: This result has been committed to this PR, if it differs from the current `HEAD`' || ':warning: This result is not being committed to this PR, as the commenter does not have `write` permissions' }}
+          CONFIG_REF_URL: '[${{ needs.prepare-command.outputs.config-short-hash }}](${{ github.server_url}}/${{ github.repository }}/tree/${{ needs.prepare-command.outputs.config-hash }})'
+          COMPARED_CONFIG_REF_URL: '[${{ needs.prepare-command.outputs.compared-config-short-hash }}](${{ github.server_url }}/${{ github.repository }}/tree/${{ needs.prepare-command.outputs.compared-config-hash }})'
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
             ${{ env.RESULT }}
+
             When comparing:
 
-            - `${{ needs.prepare-command.outputs.config-hash }}` (on branch `${{ needs.prepare-command.outputs.config-ref }}`), against
-            - `${{ needs.prepare-command.outputs.compared-config-hash }}` ${{ env.COMPARED_REF }}
+            - `${{ needs.prepare-command.outputs.config-ref }}` (checksums created using commit ${{ env.CONFIG_REF_URL }}), against
+            - `${{ needs.prepare-command.outputs.compared-config-ref }}` (checksums in commit ${{ env.COMPARED_CONFIG_REF_URL }})
 
-            ${{ needs.prepare-command.outputs.has-commit-permission != '' && env.COMMIT_RESULT || '' }}
+            ${{ needs.prepare-command.outputs.commit-requested == 'true' && ':wrench: This result has been committed to this PR, if it differs from the current `HEAD`' || '' }}
 
             <details>
             <summary> Further information</summary>
 
             The experiment can be found on Gadi at `${{ needs.repro.outputs.experiment-location }}`, and the test results at ${{ steps.results.outputs.check-run-url }}.
 
-            The checksums generated by this `!repro` command are found in the `testing/checksum` directory of ${{ needs.repro.outputs.artifact-url }}.
+            The checksums generated by this `!test` command are found in the `testing/checksum` directory of ${{ needs.repro.outputs.artifact-url }}.
 
             The checksums compared against are found here ${{ github.server_url }}/${{ github.repository }}/tree/${{ needs.prepare-command.outputs.compared-config-hash }}/testing/checksum
 
@@ -237,7 +263,7 @@ jobs:
 
   commit:
     name: Commit Result
-    if: needs.prepare-command.outputs.has-commit-permission == 'true'
+    if: needs.prepare-command.outputs.commit-requested != 'true'
     needs:
       - prepare-command
       - repro
@@ -290,10 +316,18 @@ jobs:
 
   failure-notifier:
     name: Notify PR of Workflow Failure
+    # We need the last jobs as 'needs' on the failure notifier so
+    # any of the dependent jobs that fail are covered here
+    needs:
+      - permission-check
+      - check-repro
+      - commit
     if: failure()
     runs-on: ubuntu-latest
     steps:
       - uses: access-nri/actions/.github/actions/pr-comment@main
         with:
-          comment: |
-            :x: `!test` Command Failed. See ${{ env.RUN_URL }} :x:
+          comment: >-
+            :x: `!test` Command Failed. :x:
+            ${{ needs.permission-check.result == 'failure' && 'You do not have at least write permissions on this repository.' || '' }}
+            See ${{ env.RUN_URL }}

--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -119,7 +119,16 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Get test type
+      - name: Verify !test
+        run: |
+          if [[ "${{ startsWith(github.event.comment.body, '!test') }}" == "true" ]]; then
+            echo 'Command starts with !test'
+          else
+            echo "::error::Usage: ${{ env.USAGE }}"
+            echo "::error::Command must start with !test to invoke model-config-tests' config-comment-test.yml."
+            exit 1
+
+      - name: Get !test type
         id: test
         run: |
           command="${{ github.event.comment.body }}"

--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -276,7 +276,7 @@ jobs:
             - `${{ needs.prepare-command.outputs.config-ref }}` (checksums created using commit ${{ env.CONFIG_REF_URL }}), against
             - `${{ needs.prepare-command.outputs.compared-config-ref }}` (checksums in commit ${{ env.COMPARED_CONFIG_REF_URL }})
 
-            ${{ needs.prepare-command.outputs.commit-requested == 'true' && ':wrench: This result will be committed to this PR, if it differs from the current `HEAD`' || '' }}
+            ${{ (needs.prepare-command.outputs.commit-requested == 'true' && steps.results.outputs.result == 'fail') && ':wrench: The checksums will be committed to this PR, as they differ.' || '' }}
 
             <details>
             <summary> Further information</summary>
@@ -350,6 +350,7 @@ jobs:
     # any of the dependent jobs that fail are covered here
     needs:
       - permission-check
+      - prepare-command
       - check-repro
       - commit
     if: failure()
@@ -358,6 +359,8 @@ jobs:
       - uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: >-
-            :x: `!test` Command Failed. :x:
+            :x: `!test` Command Failed :x:
+            ${{ needs.prepare-command.result == 'failure' && format('The command given could not be parsed correctly. Usage: {0}', env.USAGE) || '' }}
             ${{ needs.permission-check.result == 'failure' && 'You do not have at least write permissions on this repository.' || '' }}
+            ${{ needs.commit.result == 'failure' && 'There was a problem committing the result of the reproducibility run.' || '' }}
             See ${{ env.RUN_URL }}

--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -2,7 +2,7 @@ name: 'Comment Command: !test'
 run-name: '!test on ${{ github.repository }}'
 on:
   workflow_call:
-  # Triggered by:
+  # Triggered in calling workflow by:
   # on:
   #   issue_comment:
   #     - edited

--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -2,16 +2,6 @@ name: 'Comment Command: !test'
 run-name: '!test on ${{ github.repository }}'
 on:
   workflow_call:
-    inputs:
-      additional-artifact-content-paths:
-        type: string
-        required: false
-        # For example, the value of 'checksum' will expand to something like
-        # '/scratch/tm70/repro-ci/experiments/MODEL-configs/dev-CONFIG/checksum'
-        # on the remote.
-        description: |
-          Newline-separated paths for inclusion in the release artifact.
-          Note that all paths given have 'env.EXPERIMENT_LOCATION/' prepended.
   # Triggered by:
   # on:
   #   issue_comment:
@@ -172,7 +162,6 @@ jobs:
       payu-version: ${{ needs.ci-config.outputs.payu-version }}
       model-config-tests-version: ${{ needs.ci-config.outputs.model-config-tests-version }}
       test-markers: ${{ needs.ci-config.outputs.markers }}
-      additional-artifact-content-paths: ${{ inputs.additional-artifact-content-paths }}
     secrets: inherit
     permissions:
       contents: write
@@ -199,7 +188,7 @@ jobs:
         id: tests
         uses: EnricoMi/publish-unit-test-result-action/composite@e780361cd1fc1b1a170624547b3ffda64787d365  #v2.12.0
         with:
-          files: ${{ env.TESTING_LOCAL_LOCATION }}/testing/checksum/test_report.xml
+          files: ${{ env.TESTING_LOCAL_LOCATION }}/checksum/test_report.xml
           comment_mode: off
           check_run: true
           compare_to_earlier_commit: false
@@ -278,9 +267,9 @@ jobs:
           path: ${{ env.ARTIFACT_LOCAL_LOCATION }}
 
       - name: Update files
-        # This will copy checksums, as well as any other files specified by inputs.additional-artifact-content-paths
+        # This will copy checksums from the artifact to the repo
         run: |
-          cp --recursive --verbose ${{ env.ARTIFACT_LOCAL_LOCATION }} .
+          cp --recursive --verbose ${{ env.ARTIFACT_LOCAL_LOCATION }}/*/* testing
 
       - name: Import Commit-Signing Key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
@@ -296,7 +285,7 @@ jobs:
 
       - name: Commit and Push Updates
         run: |
-          git commit -am "Updated files as part of ${{ env.RUN_URL }}"
+          git commit -am "Updated checksums as part of ${{ env.RUN_URL }}"
           git push
 
   failure-notifier:

--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -1,5 +1,5 @@
-name: 'Comment Command: !repro'
-run-name: '!repro on ${{ github.repository }}'
+name: 'Comment Command: !test'
+run-name: '!test on ${{ github.repository }}'
 on:
   workflow_call:
     inputs:
@@ -18,7 +18,8 @@ on:
   #     - edited
   #     - created
 env:
-  USAGE: '!test repro [commit]'
+  USAGE: '!test TYPE [commit]'
+  USAGE_TYPES: repro
   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 jobs:
   ci-config:
@@ -65,6 +66,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     outputs:
+      test-type: ${{ steps.test.outputs.type }}
       # the git hash of the configuration being tested
       config-hash: ${{ steps.pr.outputs.hash }}
       # the git ref (branch or tag) of the configuration being tested
@@ -80,7 +82,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: React to '!repro'
+      - name: React to '!test'
         uses: access-nri/actions/.github/actions/react-to-comment@main
         with:
           reaction: rocket
@@ -90,6 +92,28 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Get test type
+        id: test
+        run: |
+          command="${{ github.event.issue.comment.body }}"
+          read -ra command_tokens <<< "$command"
+          type_in_comment="${command_tokens[1]}"
+          type_in_comment_valid=false
+
+          for type in ${{ env.USAGE_TYPES }}; do
+            if [[ "$type_in_command" == "$type" ]]; then
+              type_in_comment_valid=true
+              break
+            fi
+          done
+
+          if [[ "$type_in_comment_valid" == "false" ]]; then
+            echo "::error::The command '${{ github.event.issue.comment.body }}' doesn't have a valid TYPE. Was given '$type_in_command', but needed to be one of: ${{ env.USAGE_TYPES }}."
+            exit 1
+          fi
+
+          echo "type=$type_in_command" >> $GITHUB_OUTPUT
 
       - name: Get config ref from PR comment
         id: pr
@@ -139,6 +163,7 @@ jobs:
     needs:
       - prepare-command
       - ci-config
+    if: needs.prepare-command.outputs.test-type == 'repro'
     uses: access-nri/model-config-tests/.github/workflows/test-repro.yml@main
     with:
       config-ref: ${{ needs.prepare-command.outputs.config-hash }}
@@ -273,3 +298,13 @@ jobs:
         run: |
           git commit -am "Updated files as part of ${{ env.RUN_URL }}"
           git push
+
+  failure-notifier:
+    name: Notify PR of Workflow Failure
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: access-nri/actions/.github/actions/pr-comment@main
+        with:
+          comment: |
+            :x: `!test` Command Failed. See ${{ env.RUN_URL }} :x:

--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -170,13 +170,35 @@ jobs:
         id: commit
         # Determine whether the commenter wants to commit something to the repository
         run: |
-          if [[ "${{ contains(github.event.comment.body, 'commit') }}" == "false" ]]; then
+          command="${{ github.event.comment.body }}"
+          read -ra command_tokens <<< "$command"
+          potential_commit_token="${command_tokens[2]}"
+
+          if [[ "$potential_commit_token" == "commit" ]]; then
+            echo "'commit' option given"
+            echo "requested=true" >> $GITHUB_OUTPUT
+          elif [ -z "$potential_commit_token" ]; then
             echo "'commit' option not given"
             echo "requested=false" >> $GITHUB_OUTPUT
           else
-            echo "'commit' option given"
-            echo "requested=true" >> $GITHUB_OUTPUT
+            echo "::error::Non-commit option '$potential_commit_token' given. Usage: ${{ env.USAGE }}"
+            exit 1
           fi
+
+      - name: Erroneous tokens check
+        # If commit is given, any tokens after the 3rd are considered erroneous - otherwise it is after the 2nd
+        # TODO: This will need to be made more robust if there are other options added
+        run: |
+          command="${{ github.event.comment.body }}"
+          read -ra command_tokens <<< "$command"
+
+          max_tokens_allowed=$([[ "${{ steps.commit.outputs.requested }}" == "true" ]] && echo "3" || echo "2")
+
+          if [ "${#command_tokens[@]}" -gt "$max_tokens_allowed" ]; then
+            echo "::error::Erroneous tokens given. Usage: ${{ env.USAGE }}"
+            exit 1
+          fi
+
   repro:
     name: Compare ${{ needs.prepare-command.outputs.config-ref }} against ${{ needs.prepare-command.outputs.compared-config-ref }}
     needs:

--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -15,6 +15,10 @@ jobs:
   permission-check:
     name: Permission Check
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    permissions:
+      pull-requests: write
     steps:
       - name: Determine if commenter has permission to run the command
         id: commenter
@@ -24,7 +28,7 @@ jobs:
               repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission \
               --jq '.permission'
           )
-          if [[ "$commenter_permission" == "admin" || "$commenter_permission" == "write" ]]; then
+          if [[ "$commenter_permissions" == "admin" || "$commenter_permissions" == "write" ]]; then
             echo "Commenter has at least write permission"
             echo "permission=true" >> $GITHUB_OUTPUT
           else
@@ -132,7 +136,7 @@ jobs:
 
           if [[ "$type_in_comment_valid" == "false" ]]; then
             echo "::error::Usage: ${{ env.USAGE }}"
-            echo "::error::The command '${{ github.event.comment.body }}' doesn't have a valid TYPE. Was given '$type_in_command', but needed to be one of: ${{ env.USAGE_TYPES }}."
+            echo "::error::The command '${{ github.event.comment.body }}' doesn't have a valid TYPE. Was given '$type_in_comment', but needed to be one of: ${{ env.USAGE_TYPES }}."
             exit 1
           fi
 
@@ -203,6 +207,8 @@ jobs:
     permissions:
       pull-requests: write
       checks: write
+    outputs:
+      result: ${{ steps.results.outputs.result }}
     steps:
       - name: Download Newly Created Checksum
         uses: actions/download-artifact@v4
@@ -248,7 +254,7 @@ jobs:
             - `${{ needs.prepare-command.outputs.config-ref }}` (checksums created using commit ${{ env.CONFIG_REF_URL }}), against
             - `${{ needs.prepare-command.outputs.compared-config-ref }}` (checksums in commit ${{ env.COMPARED_CONFIG_REF_URL }})
 
-            ${{ needs.prepare-command.outputs.commit-requested == 'true' && ':wrench: This result has been committed to this PR, if it differs from the current `HEAD`' || '' }}
+            ${{ needs.prepare-command.outputs.commit-requested == 'true' && ':wrench: This result will be committed to this PR, if it differs from the current `HEAD`' || '' }}
 
             <details>
             <summary> Further information</summary>
@@ -263,7 +269,7 @@ jobs:
 
   commit:
     name: Commit Result
-    if: needs.prepare-command.outputs.commit-requested != 'true'
+    if: needs.prepare-command.outputs.commit-requested == 'true' && needs.check-repro.outputs.result == 'fail'
     needs:
       - prepare-command
       - repro
@@ -295,6 +301,7 @@ jobs:
       - name: Update files
         # This will copy checksums from the artifact to the repo
         run: |
+          mkdir testing
           cp --recursive --verbose ${{ env.ARTIFACT_LOCAL_LOCATION }}/*/* testing
 
       - name: Import Commit-Signing Key
@@ -311,7 +318,8 @@ jobs:
 
       - name: Commit and Push Updates
         run: |
-          git commit -am "Updated checksums as part of ${{ env.RUN_URL }}"
+          git add .
+          git commit -m "Updated checksums as part of ${{ env.RUN_URL }}"
           git push
 
   failure-notifier:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This repository houses pytests that are used as part CI checks for model configu
 
 The checksum pytests are used for reproducibility CI checks in this repository. The quick configuration tests are used in any repository that calls `config-pr-1-ci.yml` or is templated by [`ACCESS-NRI/model-configs-template](https://github.com/ACCESS-NRI/model-configs-template). For example, [ACCESS-NRI/access-om2-configs](https://github.com/ACCESS-NRI/access-om2-configs).
 
-Code from these pytests is adapted from COSIMAS's ACCESS-OM2's [
-bit reproducibility tests](https://github.com/COSIMA/access-om2/blob/master/test/test_bit_reproducibility.py).
+Code from these pytests is adapted from COSIMAS's ACCESS-OM2's [bit reproducibility tests](https://github.com/COSIMA/access-om2/blob/master/test/test_bit_reproducibility.py).
 
 ## Pytests
 
@@ -110,11 +109,11 @@ The `config-*.yml`, `generate-checksums.yml` and `test-repro.yml` workflows are 
 
 Currently, these repositories make use of the reusable CI:
 
-* [access-om2-configs](https://github.com/ACCESS-NRI/access-om2-configs)
-* [access-esm1.5-configs](https://github.com/ACCESS-NRI/access-esm1.5-configs)
-* [access-esm1.6-configs](https://github.com/ACCESS-NRI/access-esm1.6-configs)
-* [access-om3-configs](https://github.com/ACCESS-NRI/access-om3-configs)
-* [access-om3-wav-configs](https://github.com/ACCESS-NRI/access-om3-wav-configs)
+- [access-om2-configs](https://github.com/ACCESS-NRI/access-om2-configs)
+- [access-esm1.5-configs](https://github.com/ACCESS-NRI/access-esm1.5-configs)
+- [access-esm1.6-configs](https://github.com/ACCESS-NRI/access-esm1.6-configs)
+- [access-om3-configs](https://github.com/ACCESS-NRI/access-om3-configs)
+- [access-om3-wav-configs](https://github.com/ACCESS-NRI/access-om3-wav-configs)
 
 Below is information on the use of these workflows.
 
@@ -158,10 +157,12 @@ It requires all the `secrets`/`vars` defined on the caller (as above), as well a
 Usage is as follows:
 
 ```txt
-!repro [compare COMMITISH]
+!repro [commit] [compare COMMITISH]
 ```
 
- Which gives two main variations:
+Using `commit` as an option will commit the result of the repro test to the PR, provided the commenter has at least `write` permission, and the checksums differ.
+
+`[compare COMMITISH]` gives two main variations on the compared configuration:
 
 `!repro`: will compare the `HEAD` of the current PR source branch against the common ancestor on the target branch. For example, in the below diagram we would be comparing `C` against `A`:
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Using it has some requirements outside of just filling in the inputs: One must h
 - `vars.MODULE_LOCATION` - directory on the deployment target that contains module files for payu used during reproducibility testing (ex. `/g/data/vk83/modules`)
 - `vars.PRERELEASE_MODULE_LOCATION` - directory on the deployment target that contains module files for development version of payu (ex. `/g/data/vk83/prerelease/modules`)
 
-#### `config-comment-repro` Reusable Workflow
+#### `config-comment-test` Reusable Workflow
 
 This comment command allows a repro check from any branch, rather than just the `dev-*` -> `release-*` PR pipeline.
 
@@ -157,14 +157,16 @@ It requires all the `secrets`/`vars` defined on the caller (as above), as well a
 Usage is as follows:
 
 ```txt
-!repro [commit] [compare COMMITISH]
+!test TYPE [commit]
 ```
 
-Using `commit` as an option will commit the result of the repro test to the PR, provided the commenter has at least `write` permission, and the checksums differ.
+Where `TYPE` is a test suite that we support. Currently, this consists of `repro`.
 
-`[compare COMMITISH]` gives two main variations on the compared configuration:
+Using `commit` as an option will commit the result of the test to the PR, provided the commenter has at least `write` permission, and the checksums differ.
 
-`!repro`: will compare the `HEAD` of the current PR source branch against the common ancestor on the target branch. For example, in the below diagram we would be comparing `C` against `A`:
+##### `!test repro`
+
+`!test repro`: will compare the `HEAD` of the current PR source branch against the common ancestor on the target branch. For example, in the below diagram we would be comparing generated checksums in `C` against checksums already stored at `A`:
 
 ```txt
 D   (PR Target Branch)
@@ -175,5 +177,3 @@ D   (PR Target Branch)
 |/
 A   (Common Ancestor)
 ```
-
-`!repro compare COMMITISH` will compare the `HEAD` of the current PR source branch against `COMMITISH` (provided there is a `testing/checksum` directory at that point to compare against!)

--- a/README.md
+++ b/README.md
@@ -148,3 +148,31 @@ Using it has some requirements outside of just filling in the inputs: One must h
 - `vars.EXPERIMENTS_LOCATION` - directory on the deployment target that will contain all the experiments used during testing of reproducibility across multiple runs of this workflow (ex. `/scratch/some/directory/experiments`)
 - `vars.MODULE_LOCATION` - directory on the deployment target that contains module files for payu used during reproducibility testing (ex. `/g/data/vk83/modules`)
 - `vars.PRERELEASE_MODULE_LOCATION` - directory on the deployment target that contains module files for development version of payu (ex. `/g/data/vk83/prerelease/modules`)
+
+#### `config-comment-repro` Reusable Workflow
+
+This comment command allows a repro check from any branch, rather than just the `dev-*` -> `release-*` PR pipeline.
+
+It requires all the `secrets`/`vars` defined on the caller (as above), as well as `vars.CONFIG_CI_SCHEMA_VERSION`.
+
+Usage is as follows:
+
+```txt
+!repro [compare COMMITISH]
+```
+
+ Which gives two main variations:
+
+`!repro`: will compare the `HEAD` of the current PR source branch against the common ancestor on the target branch. For example, in the below diagram we would be comparing `C` against `A`:
+
+```txt
+D   (PR Target Branch)
+|
+| C (PR Source Branch)
+| |
+| B
+|/
+A   (Common Ancestor)
+```
+
+`!repro compare COMMITISH` will compare the `HEAD` of the current PR source branch against `COMMITISH` (provided there is a `testing/checksum` directory at that point to compare against!)

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Usage is as follows:
 
 Where `TYPE` is a test suite that we support. Currently, this consists of `repro`.
 
+The commands are all case sensitive and require lower case.
+
 Using `commit` as an option will commit the result of the test to the PR, provided the commenter has at least `write` permission, and the checksums differ.
 
 ##### `!test repro`


### PR DESCRIPTION
Add a `!test repro [commit]` command to allow commenters to commit and compare repro runs that aren't on `release-*` branches. 

In this PR:
- **Add config-comment-repro.yml workflow for repro tests on any branch!**
- **Added ability to commit the result of the repro test to the PR**

Closes #38
