### PR TITLE
Explicit `git checkout` of Ref to Allow For Hash `inputs.[compared-]config-ref`

### DIFF
--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -107,12 +107,14 @@ jobs:
           fi
 
           # Setup a base experiment
-          git clone ${{ github.event.repository.clone_url }} "${{ env.BASE_EXPERIMENT_LOCATION }}" -b ${{ inputs.config-ref }}
+          git clone ${{ github.event.repository.clone_url }} "${{ env.BASE_EXPERIMENT_LOCATION }}"
+          git -C "${{ env.BASE_EXPERIMENT_LOCATION }}" checkout ${{ inputs.config-ref }}
           cd "${{ env.BASE_EXPERIMENT_LOCATION }}"
 
           # Setup a compared checksum (if it exists)
           if [ -n "${{ inputs.compared-config-ref }}" ]; then
-            git clone ${{ github.event.repository.clone_url }} "${{ env.COMPARED_CHECKSUM_LOCATION }}" -b ${{ inputs.compared-config-ref }}
+            git clone ${{ github.event.repository.clone_url }} "${{ env.COMPARED_CHECKSUM_LOCATION }}"
+            git -C "${{ env.COMPARED_CHECKSUM_LOCATION }}" checkout ${{ inputs.compared-config-ref }}
             COMPARED_CHECKSUM_FILE=$(find "${{ env.COMPARED_CHECKSUM_LOCATION }}" -type f -name 'historical-*hr-checksum.json')
 
             # Error checking...


### PR DESCRIPTION
This fixes the issue in which the `test-repro` workflow fails when we give a `inputs.[compared-]config-ref` that is a hash, since `git clone -b` only accepts branch names. 

In this PR:
* Instead of trying to save every byte of space in existence by doing `git clone access-nri/CONFIG_REPO -b ${{ inputs.[compared-]config-ref }}` (which `git` says can only be a branch), explicitly call `git checkout ${{ inputs.[compared-]config-ref }}`.

This allows us to have a `inputs.config-ref`/`inputs.compared-config-ref` that is a hash rather than just a branch/tag. 

Closes #81
