### PR TITLE
Remove reference to `on.create` trigger

### DIFF
--- a/.github/workflows/config-pr-3-bump-tag.yml
+++ b/.github/workflows/config-pr-3-bump-tag.yml
@@ -9,7 +9,6 @@ on:
   #     - 'release-*'
   #   paths:
   #     - 'metadata.yaml'
-  # create: (specifically, a branch of the form 'release-*')
 jobs:
   tag-update:
     name: Check and Update Tag


### PR DESCRIPTION
References #92

## Background

We currently have a scenario in configs repositories where we push a branch and open a pull request (quite a common occurence) which is associated with two event triggers: `on.create` and `on.pull_request.types.opened`. These are both associated with the same commit.

When the `on.pull_request.types.opened` event fires, which starts the QA/Repro checks, a check run is generated that contains the test results.

Unfortunately, having multiple event triggers when adding a check run makes the run associated with either the `on.create` trigger or the `on.pull_request` trigger, nondeterministically. See https://github.com/orgs/community/discussions/24616. This means that sometimes, in the first commit of a PR, we do not get the results of the QA/Repro checks. 

Since the workarounds are quite painful, we are just removing the `on.create` trigger. This means that it will be a bit more onerous to do the initial `release-*` branch creation. It is essentially a revert of https://github.com/ACCESS-NRI/model-config-tests/issues/58
