### PR TITLE
Sanitize Inputs for `!test`

### DIFF
--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -131,7 +131,8 @@ jobs:
       - name: Get !test type
         id: test
         run: |
-          command="${{ github.event.comment.body }}"
+          # Only get the first line of the comment for processing as a command.
+          command=$(head -n 1 <<< "${{ github.event.comment.body }}")
           read -ra command_tokens <<< "$command"
           type_in_comment="${command_tokens[1]}"
           type_in_comment_valid=false
@@ -145,7 +146,7 @@ jobs:
 
           if [[ "$type_in_comment_valid" == "false" ]]; then
             echo "::error::Usage: ${{ env.USAGE }}"
-            echo "::error::The command '${{ github.event.comment.body }}' doesn't have a valid TYPE. Was given '$type_in_comment', but needed to be one of: ${{ env.USAGE_TYPES }}."
+            echo "::error::The command '$command' doesn't have a valid TYPE. Was given '$type_in_comment', but needed to be one of: ${{ env.USAGE_TYPES }}."
             exit 1
           fi
 
@@ -179,7 +180,8 @@ jobs:
         id: commit
         # Determine whether the commenter wants to commit something to the repository
         run: |
-          command="${{ github.event.comment.body }}"
+          # Again only taking the first line as the command
+          command=$(head -n 1 <<< "${{ github.event.comment.body }}")
           read -ra command_tokens <<< "$command"
           potential_commit_token="${command_tokens[2]}"
 
@@ -198,7 +200,8 @@ jobs:
         # If commit is given, any tokens after the 3rd are considered erroneous - otherwise it is after the 2nd
         # TODO: This will need to be made more robust if there are other options added
         run: |
-          command="${{ github.event.comment.body }}"
+          # Again only taking the first line as the command
+          command=$(head -n 1 <<< "${{ github.event.comment.body }}")
           read -ra command_tokens <<< "$command"
 
           max_tokens_allowed=$([[ "${{ steps.commit.outputs.requested }}" == "true" ]] && echo "3" || echo "2")

--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -22,28 +22,18 @@ jobs:
     steps:
       - name: Determine if commenter has permission to run the command
         id: commenter
-        # TODO: The permissions-checking section seems ripe for turning into an action!
-        run: |
-          commenter_permissions=$(gh api \
-              repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission \
-              --jq '.permission'
-          )
-          if [[ "$commenter_permissions" == "admin" || "$commenter_permissions" == "write" ]]; then
-            echo "Commenter has at least write permission"
-            echo "permission=true" >> $GITHUB_OUTPUT
-          else
-            echo "Commenter does not have at least write permission"
-            echo "permission=false" >> $GITHUB_OUTPUT
-          fi
+        uses: access-nri/actions/.github/actions/commenter-permission-check@main
+        with:
+          minimum-permission: write
 
       - name: React to '!test'
         uses: access-nri/actions/.github/actions/react-to-comment@main
         with:
-          reaction: ${{ steps.commenter.outputs.permission == 'true' && 'rocket' || 'confused' }}
+          reaction: ${{ steps.commenter.outputs.has-permission == 'true' && 'rocket' || 'confused' }}
           token: ${{ github.token }}
 
       - name: Fail if no permissions
-        if: steps.commenter.outputs.permission == 'false'
+        if: steps.commenter.outputs.has-permission == 'false'
         run: exit 1
 
   ci-config:


### PR DESCRIPTION
Closes #80

In this PR:

- **Take only the first line in a potentially multi-line comment as the command**
- **Use the commenter-permission-check action instead of defining it again**
