### PR TITLE
Delete and recreate `env.EXPERIMENTS_LOCATION` rather than wildcard

### DIFF
--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -111,7 +111,8 @@ jobs:
 
           # Remove base experiment (and everything else) if it exists
           if [ -d "${{ env.EXPERIMENT_LOCATION }}" ]; then
-            rm -rf "${{ env.EXPERIMENT_LOCATION }}/*"
+            rm -rf "${{ env.EXPERIMENT_LOCATION }}"
+            mkdir -p "${{ env.EXPERIMENT_LOCATION }}"
           fi
 
           # Setup a base experiment

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -112,8 +112,8 @@ jobs:
           # Remove base experiment (and everything else) if it exists
           if [ -d "${{ env.EXPERIMENT_LOCATION }}" ]; then
             rm -rf "${{ env.EXPERIMENT_LOCATION }}"
-            mkdir -p "${{ env.EXPERIMENT_LOCATION }}"
           fi
+          mkdir -p "${{ env.EXPERIMENT_LOCATION }}"
 
           # Setup a base experiment
           git clone ${{ github.event.repository.clone_url }} "${{ env.BASE_EXPERIMENT_LOCATION }}"


### PR DESCRIPTION
Closes #95

## Background

Rather than running into the issue of appropriately quoting and wildcarding a `rm`, delete the entire directory, then recreate it. 
