### PR TITLE
Modify esm1p5/1p6 tests for AMIP configurations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "model_config_tests"
-version = "0.0.9"
+version = "0.0.10"
 authors = [
   { name = "ACCESS-NRI" },
 ]

--- a/src/model_config_tests/qa/test_access_esm1p5_config.py
+++ b/src/model_config_tests/qa/test_access_esm1p5_config.py
@@ -28,6 +28,7 @@ VALID_NOMINAL_RESOLUTION: str = "100 km"
 VALID_REFERENCE: str = "https://doi.org/10.1071/ES19035"
 VALID_PREINDUSTRIAL_START: dict[str, int] = {"year": 101, "month": 1, "days": 1}
 VALID_HISTORICAL_START: dict[str, int] = {"year": 1850, "month": 1, "days": 1}
+VALID_AMIP_START: dict[str, int] = {"year": 1978, "month": 1, "days": 1}
 VALID_RUNTIME: dict[str, int] = {"years": 1, "months": 0, "days": 0}
 VALID_RESTART_FREQ: str = "10YS"
 VALID_MPPNCCOMBINE_EXE: str = "mppnccombine.spack"
@@ -154,6 +155,10 @@ class TestAccessEsm1p5:
             assert start == VALID_HISTORICAL_START, error_field_incorrect(
                 "calendar.start", "config.yaml", VALID_HISTORICAL_START
             )
+        elif branch.config_scenario == "amip":
+            assert start == VALID_AMIP_START, error_field_incorrect(
+                "calendar.start", "config.yaml", VALID_AMIP_START
+            )
         else:
             pytest.fail(f"Cannot test unknown scenario {branch.config_scenario}.")
 
@@ -199,8 +204,13 @@ class TestAccessEsm1p5:
             )
 
     def test_cice_configuration_icefields_nml_in_ice_history_nml(
-        self, config, control_path
+        self, branch, config, control_path
     ):
+        if branch.config_scenario == "amip":
+            pytest.skip(
+                "amip scenarios do not contain the CICE sub-model."
+            )
+
         # Find CICE sub-model control path
         model_name = None
         for sub_model in config["submodels"]:

--- a/src/model_config_tests/qa/test_access_esm1p6_config.py
+++ b/src/model_config_tests/qa/test_access_esm1p6_config.py
@@ -29,6 +29,7 @@ VALID_NOMINAL_RESOLUTION: str = "100 km"
 # VALID_REFERENCE: str = "https://doi.org/10.1071/ES19035"
 VALID_PREINDUSTRIAL_START: dict[str, int] = {"year": 101, "month": 1, "days": 1}
 VALID_HISTORICAL_START: dict[str, int] = {"year": 1850, "month": 1, "days": 1}
+VALID_AMIP_START: dict[str, int] = {"year": 1978, "month": 1, "days": 1}
 VALID_RUNTIME: dict[str, int] = {"years": 1, "months": 0, "days": 0}
 VALID_RESTART_FREQ: str = "10YS"
 VALID_MPPNCCOMBINE_EXE: str = "mppnccombine.spack"
@@ -173,6 +174,10 @@ class TestAccessEsm1p6:
             assert start == VALID_HISTORICAL_START, error_field_incorrect(
                 "calendar.start", "config.yaml", VALID_HISTORICAL_START
             )
+        elif branch.config_scenario == "amip":
+            assert start == VALID_AMIP_START, error_field_incorrect(
+                "calendar.start", "config.yaml", VALID_AMIP_START
+            )
         else:
             pytest.fail(f"Cannot test unknown scenario {branch.config_scenario}.")
 
@@ -218,8 +223,13 @@ class TestAccessEsm1p6:
             )
 
     def test_cice_configuration_icefields_nml_in_ice_history_nml(
-        self, config, control_path
+        self, branch, config, control_path
     ):
+        if branch.config_scenario == "amip":
+            pytest.skip(
+                "amip scenarios do not contain the CICE sub-model."
+            )
+
         # Find CICE sub-model control path
         model_name = None
         for sub_model in config["submodels"]:


### PR DESCRIPTION
Closes #97 

This PR adds 1978-01-01 as a valid start date for the atmosphere-only (AMIP) configurations of ESM1.5 and 1.6. It also skips the `test_cice_configuration_icefields_nml_in_ice_history_nml` test for amip configurations, as these don't contain a CICE sub-model.
