### PR TITLE
Fix bug in ACCESS-OM3 reproducibility tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "model_config_tests"
-version = "0.0.10"
+version = "0.0.11"
 authors = [
   { name = "ACCESS-NRI" },
 ]

--- a/src/model_config_tests/models/accessom3.py
+++ b/src/model_config_tests/models/accessom3.py
@@ -12,6 +12,7 @@ from model_config_tests.models.model import (
     SCHEMA_VERSION_1_0_0,
     Model,
 )
+from model_config_tests.util import DAY_IN_SECONDS
 
 
 class AccessOm3(Model):
@@ -20,6 +21,7 @@ class AccessOm3(Model):
         self.output_file = self.experiment.output000 / "ocean.stats"
 
         self.runconfig = experiment.control_path / "nuopc.runconfig"
+        self.mom_override = experiment.control_path / "MOM_override"
         self.ocean_config = experiment.control_path / "input.nml"
 
     def set_model_runtime(
@@ -32,6 +34,16 @@ class AccessOm3(Model):
         if years == months == 0:
             freq = "nseconds"
             n = str(seconds)
+
+            # Ensure that ocean.stats are written at the end of the run
+            if seconds < DAY_IN_SECONDS:
+                with open(self.mom_override, "a") as f:
+                    f.writelines(
+                        [
+                            f"\n#override TIMEUNIT = {n}",
+                            "\n#override ENERGYSAVEDAYS = 1.0",
+                        ]
+                    )
         elif seconds == 0:
             freq = "nmonths"
             n = str(12 * years + months)

--- a/src/model_config_tests/qa/test_access_esm1p5_config.py
+++ b/src/model_config_tests/qa/test_access_esm1p5_config.py
@@ -207,9 +207,7 @@ class TestAccessEsm1p5:
         self, branch, config, control_path
     ):
         if branch.config_scenario == "amip":
-            pytest.skip(
-                "amip scenarios do not contain the CICE sub-model."
-            )
+            pytest.skip("amip scenarios do not contain the CICE sub-model.")
 
         # Find CICE sub-model control path
         model_name = None

--- a/src/model_config_tests/qa/test_access_esm1p6_config.py
+++ b/src/model_config_tests/qa/test_access_esm1p6_config.py
@@ -226,9 +226,7 @@ class TestAccessEsm1p6:
         self, branch, config, control_path
     ):
         if branch.config_scenario == "amip":
-            pytest.skip(
-                "amip scenarios do not contain the CICE sub-model."
-            )
+            pytest.skip("amip scenarios do not contain the CICE sub-model.")
 
         # Find CICE sub-model control path
         model_name = None


### PR DESCRIPTION
This PR ensure ocean.stats are written an the end of runs of less than one day. Closes #100 