### PR TITLE
Changes to support OM3 development branches in QA checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .idea
 /tests/tmp/
 coverage.xml
+/model-conf-test/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 .idea
 /tests/tmp/
 coverage.xml
-/model-conf-test/

--- a/src/model_config_tests/conftest.py
+++ b/src/model_config_tests/conftest.py
@@ -115,7 +115,8 @@ def pytest_configure(config):
         "markers", "checksum_slow: mark tests as slow reproducibility tests"
     )
     config.addinivalue_line(
-        "markers", "config: mark as configuration tests for release branches in quick QA CI checks"
+        "markers",
+        "config: mark as configuration tests for release branches in quick QA CI checks",
     )
     config.addinivalue_line(
         "markers", "dev_config: mark as configuration tests in quick QA CI checks"

--- a/src/model_config_tests/conftest.py
+++ b/src/model_config_tests/conftest.py
@@ -115,7 +115,10 @@ def pytest_configure(config):
         "markers", "checksum_slow: mark tests as slow reproducibility tests"
     )
     config.addinivalue_line(
-        "markers", "config: mark as configuration tests in quick QA CI checks"
+        "markers", "config: mark as configuration tests for release branches in quick QA CI checks"
+    )
+    config.addinivalue_line(
+        "markers", "devconfig: mark as configuration tests in quick QA CI checks"
     )
     config.addinivalue_line(
         "markers", "access_om2: mark as ACCESS-OM2 specific tests in quick QA CI checks"

--- a/src/model_config_tests/conftest.py
+++ b/src/model_config_tests/conftest.py
@@ -118,7 +118,7 @@ def pytest_configure(config):
         "markers", "config: mark as configuration tests for release branches in quick QA CI checks"
     )
     config.addinivalue_line(
-        "markers", "devconfig: mark as configuration tests in quick QA CI checks"
+        "markers", "dev_config: mark as configuration tests in quick QA CI checks"
     )
     config.addinivalue_line(
         "markers", "access_om2: mark as ACCESS-OM2 specific tests in quick QA CI checks"

--- a/src/model_config_tests/qa/test_access_om3_config.py
+++ b/src/model_config_tests/qa/test_access_om3_config.py
@@ -7,6 +7,7 @@ import pytest
 
 from model_config_tests.qa.test_config import check_manifest_exes_in_spack_location
 
+
 @pytest.mark.access_om3
 class TestAccessOM3:
     """ACCESS-OM3 Specific configuration and metadata tests"""
@@ -14,10 +15,10 @@ class TestAccessOM3:
     def test_access_om3_manifest_exe_in_release_spack_location(
         self, config, control_path
     ):
-        
+
         check_manifest_exes_in_spack_location(
-            model_module_name='access-om3',
-            model_repo_name='ACCESS-OM3',
+            model_module_name="access-om3",
+            model_repo_name="ACCESS-OM3",
             control_path=control_path,
             config=config,
         )

--- a/src/model_config_tests/qa/test_access_om3_config.py
+++ b/src/model_config_tests/qa/test_access_om3_config.py
@@ -5,10 +5,19 @@
 
 import pytest
 
+from model_config_tests.qa.test_config import check_manifest_exes_in_spack_location
 
 @pytest.mark.access_om3
 class TestAccessOM3:
     """ACCESS-OM3 Specific configuration and metadata tests"""
 
-    def test_pass(self):
-        pass
+    def test_access_om3_manifest_exe_in_release_spack_location(
+        self, config, control_path
+    ):
+        
+        check_manifest_exes_in_spack_location(
+            model_module_name='access-om3',
+            model_repo_name='ACCESS-OM3',
+            control_path=control_path,
+            config=config,
+        )

--- a/src/model_config_tests/qa/test_config.py
+++ b/src/model_config_tests/qa/test_config.py
@@ -98,6 +98,21 @@ class TestRelConfig:
                 "path" in config["sync"] and config["sync"]["path"] is not None
             ), "Sync path to remote archive should not be set"
 
+    def test_manifest_reproduce_exe_is_on(self, config):
+        manifest_reproduce = config.get("manifest", {}).get("reproduce", {})
+        assert "exe" in manifest_reproduce and manifest_reproduce["exe"], (
+            "Executable reproducibility should be enforced, e.g set:\n"
+            + "manifest:\n    reproduce:\n        exe: True"
+        )
+
+    def test_metadata_is_enabled(self, config):
+        if "metadata" in config and "enable" in config["metadata"]:
+            assert config["metadata"]["enable"], (
+                "Metadata should be enabled, otherwise new UUIDs will not "
+                + "be generated and branching in Payu would not work - as "
+                + "branch and UUIDs are not used in the name used for archival."
+            )
+
     def test_experiment_name_is_not_defined(self, config):
         assert "experiment" not in config, (
             f"experiment: {config['experiment']} should not set, "
@@ -157,38 +172,7 @@ class TestRelConfig:
         assert (
             "license" in metadata and metadata["license"] == LICENSE
         ), f"The license should be set to {LICENSE}"
-
-    def test_manifest_reproduce_exe_is_on(self, config):
-        manifest_reproduce = config.get("manifest", {}).get("reproduce", {})
-        assert "exe" in manifest_reproduce and manifest_reproduce["exe"], (
-            "Executable reproducibility should be enforced, e.g set:\n"
-            + "manifest:\n    reproduce:\n        exe: True"
-        )
-
-    def test_metadata_is_enabled(self, config):
-        if "metadata" in config and "enable" in config["metadata"]:
-            assert config["metadata"]["enable"], (
-                "Metadata should be enabled, otherwise new UUIDs will not "
-                + "be generated and branching in Payu would not work - as "
-                + "branch and UUIDs are not used in the name used for archival."
-            )
-            
-    def test_model_module_path_is_defined(self, branch_type, config):
-        """Check model module path is added to modules in config"""
-        if branch_type == "release":
-            module_paths = config.get("modules", {}).get("use", {})
-            assert RELEASE_MODULE_LOCATION in module_paths, (
-                "Expected model module path is added to module config. E.g.\n"
-                "  modules:\n"
-                "   use:\n"
-                f"    - {RELEASE_MODULE_LOCATION}\n"
-                "This path is used to find model module files"
-            )
-        else:
-            pytest.skip(
-                "The target branch is a dev version and doesn't require a stable module location"
-            )
-
+                
 @pytest.mark.config
 @pytest.mark.devconfig
 class TestDevConfig:
@@ -237,6 +221,22 @@ class TestDevConfig:
         assert content == license, (
             f"LICENSE file should be equal to {LICENSE} found here: " + LICENSE_URL
         )
+
+    def test_model_module_path_is_defined(self, branch_type, config):
+        """Check model module path is added to modules in config"""
+        if branch_type == "release":
+            module_paths = config.get("modules", {}).get("use", {})
+            assert RELEASE_MODULE_LOCATION in module_paths, (
+                "Expected model module path is added to module config. E.g.\n"
+                "  modules:\n"
+                "   use:\n"
+                f"    - {RELEASE_MODULE_LOCATION}\n"
+                "This path is used to find model module files"
+            )
+        else:
+            pytest.skip(
+                "The target branch is a dev version and doesn't require a stable module location"
+            )
 
 
 def read_exe_manifest_fullpaths(control_path: Path):

--- a/src/model_config_tests/qa/test_config.py
+++ b/src/model_config_tests/qa/test_config.py
@@ -174,8 +174,8 @@ class TestRelConfig:
         ), f"The license should be set to {LICENSE}"
                 
 @pytest.mark.config
-@pytest.mark.devconfig
-class TestDevConfig:
+@pytest.mark.dev_config
+class TestConfig:
     """General configuration tests"""
 
     @pytest.mark.parametrize("field", ["project", "shortpath"])

--- a/src/model_config_tests/qa/test_config.py
+++ b/src/model_config_tests/qa/test_config.py
@@ -86,18 +86,6 @@ class TestRelConfig:
             "Restart frequency should be date-based: " + f"'restart_freq: {frequency}'"
         )
 
-    def test_sync_is_not_enabled(self, config):
-        if "sync" in config and "enable" in config["sync"]:
-            assert not config["sync"][
-                "enable"
-            ], "Sync to remote archive should not be enabled"
-
-    def test_sync_path_is_not_set(self, config):
-        if "sync" in config:
-            assert not (
-                "path" in config["sync"] and config["sync"]["path"] is not None
-            ), "Sync path to remote archive should not be set"
-
     def test_manifest_reproduce_exe_is_on(self, config):
         manifest_reproduce = config.get("manifest", {}).get("reproduce", {})
         assert "exe" in manifest_reproduce and manifest_reproduce["exe"], (
@@ -112,13 +100,6 @@ class TestRelConfig:
                 + "be generated and branching in Payu would not work - as "
                 + "branch and UUIDs are not used in the name used for archival."
             )
-
-    def test_experiment_name_is_not_defined(self, config):
-        assert "experiment" not in config, (
-            f"experiment: {config['experiment']} should not set, "
-            + "as this over-rides the experiment name used for archival. "
-            + "If set, branching in payu would not work."
-        )
 
     def test_no_scripts_in_top_level_directory(self, control_path):
         exts = {".py", ".sh"}
@@ -162,17 +143,12 @@ class TestRelConfig:
     def test_metadata_contains_fields(self, field, metadata):
         assert field in metadata, f"{field} field shoud be defined in metadata"
 
-    def test_metadata_does_contain_UUID(self, metadata):
-        assert "experiment_uuid" not in metadata, (
-            "`experiment_uuid` should not be defined in metadata, "
-            + "as this is an configuration rather than an experiment. "
-        )
-
     def test_metadata_license(self, metadata):
         assert (
             "license" in metadata and metadata["license"] == LICENSE
         ), f"The license should be set to {LICENSE}"
-                
+
+
 @pytest.mark.config
 @pytest.mark.dev_config
 class TestConfig:
@@ -201,8 +177,6 @@ class TestConfig:
         assert (
             "storage" not in qsub_flags
         ), "Storage flags defined in qsub_flags will be silently ignored"
-
-    
 
     def test_license_file(self, control_path):
         license_path = control_path / "LICENSE"
@@ -237,6 +211,31 @@ class TestConfig:
             pytest.skip(
                 "The target branch is a dev version and doesn't require a stable module location"
             )
+
+    def test_metadata_does_not_contain_UUID(self, metadata):
+        assert "experiment_uuid" not in metadata, (
+            "`experiment_uuid` should not be defined in metadata, "
+            + "as this is an configuration rather than an experiment. "
+        )
+
+    def test_sync_is_not_enabled(self, config):
+        if "sync" in config and "enable" in config["sync"]:
+            assert not config["sync"][
+                "enable"
+            ], "Sync to remote archive should not be enabled"
+
+    def test_sync_path_is_not_set(self, config):
+        if "sync" in config:
+            assert not (
+                "path" in config["sync"] and config["sync"]["path"] is not None
+            ), "Sync path to remote archive should not be set"
+
+    def test_experiment_name_is_not_defined(self, config):
+        assert "experiment" not in config, (
+            f"experiment: {config['experiment']} should not set, "
+            + "as this over-rides the experiment name used for archival. "
+            + "If set, branching in payu would not work."
+        )
 
 
 def read_exe_manifest_fullpaths(control_path: Path):


### PR DESCRIPTION
Contibrutes to #99 

This change splits the QA tests (the ones run on a github runner which don't run the model) into two sections. There is a section for Release branches and a section for Dev branches in configurations.

The dev branches tests are triggered via a new `dev_config` pytest marker. The behaviour of the existing `config` marker is unchanged, in that it runs both the tests for Release branches and those for Dev branches. The Dev branches test can be considered a subset of the tests applied for Release branches.

For consistency with other models , a test was added that the executable location is the spack release location.

@aidanheerdegen - mostly tagged you for a view on which tests should be dev vs release