### PR TITLE
`!test repro commit`: Update Commit Paths

### DIFF
--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -292,8 +292,8 @@ jobs:
       - name: Update files
         # This will copy checksums from the artifact to the repo
         run: |
-          mkdir -p testing
-          cp --recursive --verbose ${{ env.ARTIFACT_LOCAL_LOCATION }}/*/* testing
+          mkdir -p testing/checksum
+          cp --verbose ${{ env.ARTIFACT_LOCAL_LOCATION }}/checksum/historical-*hr-checksum.json testing/checksum
 
       - name: Import Commit-Signing Key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0


### PR DESCRIPTION
Closes #104, references https://github.com/ACCESS-NRI/access-om3-configs/pull/180

## Background

Currently, the `!test repro commit` command commits to the base `testing` directory, rather than the `testing/checksum` directory. It also commits the `test_report.xml` file, which we don't need. 

This PR updates the copy command to have the destination `testing/checksum`, and removes the `test_report.xml`. 
