### PR TITLE
Support regex matching when parsing CI configuration file

### DIFF
--- a/.github/actions/parse-ci-config/action.yml
+++ b/.github/actions/parse-ci-config/action.yml
@@ -49,4 +49,4 @@ runs:
         echo "payu-version=$(jq -r '.["payu-version"]' tmp-result.json)" >> $GITHUB_OUTPUT
 
         # Clean up result file
-        rm result.json
+        rm tmp-result.json

--- a/.github/actions/parse-ci-config/action.yml
+++ b/.github/actions/parse-ci-config/action.yml
@@ -24,39 +24,29 @@ outputs:
     value: ${{ steps.read-config.outputs.payu-version }}
     description: The payu version used to create test virtual environment for remote tests (e.g. repro tests)
 runs:
-  using: "composite" 
-  steps:         
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+
     - name: Read Configuration File
-      shell: bash
       id: read-config
+      shell: bash
       run: |
-        # Fall back to default config values if not defined for a given branch or tag
-        output=$(jq --arg branch "${{ inputs.branch-or-tag }}" --arg check "${{ inputs.check }}" '
-        {
-          "model-config-tests-version": (
-            .[$check][$branch]["model-config-tests-version"] //
-            .[$check].default["model-config-tests-version"] // 
-            .default["model-config-tests-version"]
-          ),
-          "python-version": (
-            .[$check][$branch]["python-version"] // 
-            .[$check].default["python-version"] // 
-            .default["python-version"]
-          ),
-          "payu-version": (
-            .[$check][$branch]["payu-version"] //
-            .[$check].default["payu-version"] //
-            .default["payu-version"]
-          ),
-          "markers": (
-            .[$check][$branch].markers // 
-            .[$check].default.markers //
-            .default.markers
-          ),
-        }
-        ' "${{ inputs.config-filepath }}")
-        
-        echo "markers=$(echo "$output" | jq -r '.["markers"]')" >> $GITHUB_OUTPUT
-        echo "python-version=$(echo "$output" | jq -r '.["python-version"]')" >> $GITHUB_OUTPUT
-        echo "payu-version=$(echo "$output" | jq -r '.["payu-version"]')" >> $GITHUB_OUTPUT
-        echo "model-config-tests-version=$(echo "$output" | jq -r '.["model-config-tests-version"]')" >> $GITHUB_OUTPUT
+        set -e
+        # Use python script in parse-ci-config directory to parse CI configuration file
+        python3 ${{ github.action_path }}/parse_file.py \
+          --test-type "${{ inputs.check }}" \
+          --reference "${{ inputs.branch-or-tag }}" \
+          --config-filepath "${{ inputs.config-filepath }}" \
+          --output-filepath tmp-result.json
+
+        echo "model-config-tests-version=$(jq -r '.["model-config-tests-version"]' tmp-result.json)" >> $GITHUB_OUTPUT
+        echo "python-version=$(jq -r '.["python-version"]' tmp-result.json)" >> $GITHUB_OUTPUT
+        echo "markers=$(jq -r '.["markers"]' tmp-result.json)" >> $GITHUB_OUTPUT
+        echo "payu-version=$(jq -r '.["payu-version"]' tmp-result.json)" >> $GITHUB_OUTPUT
+
+        # Clean up result file
+        rm result.json

--- a/.github/actions/parse-ci-config/action.yml
+++ b/.github/actions/parse-ci-config/action.yml
@@ -27,9 +27,11 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
+      id: cp311
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
+        update-environment: false
 
     - name: Read Configuration File
       id: read-config
@@ -37,7 +39,7 @@ runs:
       run: |
         set -e
         # Use python script in parse-ci-config directory to parse CI configuration file
-        python3 ${{ github.action_path }}/parse_file.py \
+        ${{ steps.cp311.outputs.python-path }} ${{ github.action_path }}/parse_file.py \
           --test-type "${{ inputs.check }}" \
           --reference "${{ inputs.branch-or-tag }}" \
           --config-filepath "${{ inputs.config-filepath }}" \

--- a/.github/actions/parse-ci-config/parse_file.py
+++ b/.github/actions/parse-ci-config/parse_file.py
@@ -1,0 +1,113 @@
+import argparse
+import json
+import re
+
+
+def get_config_value(config, test_type, reference, key):
+    """
+    Retrieve the value for a given key from the nested structure of the JSON file.
+    It first checks the specific 'test_type' and 'reference', then falls back to the default values if not found.
+
+    Parameters:
+    config (dict): The dictionary containing the CI configuration.
+    test_type (str): Type of check/test to run (e.g., "reproducibility", "qa", or "scheduled").
+    reference (str): Name of Git branch or tag to run CI testing on.
+    key (str): The key to retrieve the value for (e.g. "python-version").
+
+    Returns:
+    str: The value associated with the key.
+    """
+    # Check for exact match
+    value = config.get(test_type, {}).get(reference, {}).get(key)
+    if value:
+        return value
+
+    # Check for branch/tag with the longest regex match
+    # E.g. dev-branch-1 should match dev-branch-* over dev-*
+    longest_match = None
+    longest_match_length = 0
+    for pattern in config.get(test_type, {}):
+        match = re.match(pattern, reference)
+        if match and config[test_type][pattern].get(key):
+            match_length = len(match.group(0))
+            if match_length > longest_match_length:
+                longest_match = pattern
+                longest_match_length = match_length
+
+    if longest_match:
+        return config[test_type][longest_match].get(key)
+
+    # Check for default values for test type and the top-level default
+    return config.get(test_type, {}).get("default", {}).get(key) or config.get(
+        "default", {}
+    ).get(key)
+
+
+def parse_ci_config(test_type, reference, filepath):
+    """
+    Parse the CI configuration file and extract the test configuration
+    for a given test type and reference.
+
+    Parameters:
+    test_type (str): Type of check/test to run (e.g., "reproducibility", "qa", or "scheduled").
+    reference (str): Name of Git branch or tag to run CI testing on.
+    filepath (str): Path to the CI configuration file.
+
+    Returns:
+    dict: A dictionary containing the extracted values for 'model-config-tests-version',
+          'python-version', 'markers', and 'payu-version'.
+    """
+    with open(filepath) as file:
+        config = json.load(file)
+
+    model_config_tests_version = get_config_value(
+        config, test_type, reference, "model-config-tests-version"
+    )
+    python_version = get_config_value(config, test_type, reference, "python-version")
+    markers = get_config_value(config, test_type, reference, "markers")
+    payu_version = get_config_value(config, test_type, reference, "payu-version")
+
+    return {
+        "model-config-tests-version": model_config_tests_version,
+        "python-version": python_version,
+        "markers": markers,
+        "payu-version": payu_version,
+    }
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Parse CI configuration file.")
+    parser.add_argument(
+        "--test-type",
+        required=True,
+        help="Type of check/test to run (e.g., 'reproducibility', 'qa', or 'scheduled').",
+    )
+    parser.add_argument(
+        "--reference",
+        required=True,
+        help="Name of Git branch or tag to run CI testing on.",
+    )
+    parser.add_argument(
+        "--config-filepath", required=True, help="Path to the CI configuration file."
+    )
+    parser.add_argument(
+        "--output-filepath",
+        required=False,
+        help="Path to the output file to save the results.",
+    )
+
+    args = parser.parse_args()
+
+    test_type = args.test_type
+    reference = args.reference
+    filepath = args.config_filepath
+    output_filepath = args.output_filepath
+
+    result = parse_ci_config(test_type, reference, filepath)
+
+    if output_filepath:
+        with open(output_filepath, "w") as output_file:
+            json.dump(result, output_file, indent=4)
+    else:
+        for key, value in result.items():
+            print(f"{key}: {value}")

--- a/.github/actions/parse-ci-config/parse_file.py
+++ b/.github/actions/parse-ci-config/parse_file.py
@@ -6,7 +6,9 @@ import re
 def get_config_value(config, test_type, reference, key):
     """
     Retrieve the value for a given key from the nested structure of the JSON file.
-    It first checks the specific 'test_type' and 'reference', then falls back to the default values if not found.
+    It first checks the specific 'test_type' and 'reference', then checks
+    for a regex match with the 'reference', and then falls back to the default
+    values if key is not found.
 
     Parameters:
     config (dict): The dictionary containing the CI configuration.

--- a/.github/actions/parse-ci-config/parse_file.py
+++ b/.github/actions/parse-ci-config/parse_file.py
@@ -17,25 +17,18 @@ def get_config_value(config, test_type, reference, key):
     Returns:
     str: The value associated with the key.
     """
-    # Check for exact match
+    # Check for exact match of test_type and reference
     value = config.get(test_type, {}).get(reference, {}).get(key)
     if value:
         return value
 
-    # Check for branch/tag with the longest regex match
-    # E.g. dev-branch-1 should match dev-branch-* over dev-*
-    longest_match = None
-    longest_match_length = 0
+    # Check for reference regex match with a key defined with priority given
+    # to the first match found (so top-down order matters)
     for pattern in config.get(test_type, {}):
-        match = re.match(pattern, reference)
+        # Use fullmatch to require entire string to match pattern exactly
+        match = re.fullmatch(pattern, reference)
         if match and config[test_type][pattern].get(key):
-            match_length = len(match.group(0))
-            if match_length > longest_match_length:
-                longest_match = pattern
-                longest_match_length = match_length
-
-    if longest_match:
-        return config[test_type][longest_match].get(key)
+            return config[test_type][pattern].get(key)
 
     # Check for default values for test type and the top-level default
     return config.get(test_type, {}).get("default", {}).get(key) or config.get(

--- a/.github/actions/parse-ci-config/test_parse_file.py
+++ b/.github/actions/parse-ci-config/test_parse_file.py
@@ -1,0 +1,181 @@
+import json
+
+import pytest
+from parse_file import get_config_value, parse_ci_config
+
+
+@pytest.mark.parametrize(
+    "config, test_type, reference, key, expected",
+    [
+        # Test when key is set for reference (e.g. tag or branch)
+        (
+            {
+                "reproducibility": {
+                    "branch_name_1": {
+                        "payu-version": "1.1.3",
+                    },
+                    "default": {
+                        "payu-version": "1.1.5",
+                    },
+                },
+                "default": {
+                    "payu-version": "1.1.6",
+                },
+            },
+            "reproducibility",
+            "branch_name_1",
+            "payu-version",
+            "1.1.3",
+        ),
+        # Test when key is not set for reference but set in test default
+        (
+            {
+                "reproducibility": {
+                    "default": {
+                        "payu-version": "1.1.5",
+                    }
+                },
+                "default": {
+                    "payu-version": "1.1.6",
+                },
+            },
+            "reproducibility",
+            "branch_name_1",
+            "payu-version",
+            "1.1.5",
+        ),
+        # Test when the key is not found in the test_type and reference
+        (
+            {
+                "reproducibility": {
+                    "default": {
+                        "markers": "default-repro",
+                    }
+                },
+                "default": {
+                    "payu-version": "1.1.6",
+                },
+            },
+            "reproducibility",
+            "branch_name_1",
+            "payu-version",
+            "1.1.6",
+        ),
+        # Test when reference matches a regex pattern
+        (
+            {
+                "qa": {
+                    "dev-*": {"markers": "dev_config"},
+                    "default": {"markers": "config or dev_config"},
+                },
+            },
+            "qa",
+            "dev_branch1",
+            "markers",
+            "dev_config",
+        ),
+        # Test exact match takes precedence over regex match
+        (
+            {
+                "qa": {
+                    "dev-*": {"markers": "dev_config"},
+                    "dev_branch1": {"markers": "another_marker"},
+                    "default": {"markers": "config or dev_config"},
+                },
+            },
+            "qa",
+            "dev_branch1",
+            "markers",
+            "another_marker",
+        ),
+        # Test for the longest regex match for the branch name
+        (
+            {
+                "qa": {
+                    "dev-*": {"markers": "dev_config"},
+                    "dev_branch*": {"markers": "another_marker"},
+                    "default": {"markers": "config or dev_config"},
+                },
+            },
+            "qa",
+            "dev_branch1",
+            "markers",
+            "another_marker",
+        ),
+        # Test if regex match for branch name but payu-version is not found
+        (
+            {
+                "qa": {
+                    "dev-*": {"markers": "dev_config"},
+                    "dev_branch*": {"markers": "another_marker"},
+                    "default": {"markers": "config or dev_config"},
+                },
+                "default": {"payu-version": "1.0.0"},
+            },
+            "qa",
+            "dev_branch1",
+            "payu-version",
+            "1.0.0",
+        ),
+    ],
+)
+def test_get_config_value(config, test_type, reference, key, expected):
+    assert get_config_value(config, test_type, reference, key) == expected
+
+
+@pytest.fixture
+def sample_config():
+    return {
+        "reproducibility": {
+            "release-1deg_jra55_ryf": {
+                "markers": "repro or repro_slow",
+            },
+            "dev-*": {
+                "payu-version": "dev",
+            },
+            "dev-branch-*": {
+                "payu-version": "2.0.0",
+            },
+            "dev-branch-1": {
+                "payu-version": "3.0.0",
+            },
+            "default": {
+                "markers": "default-repro",
+            },
+        },
+        "qa": {
+            "dev-*": {
+                "markers": "config_dev",
+            },
+            "default": {
+                "markers": "config or config_dev",
+            },
+        },
+        "default": {
+            "model-config-tests-version": "1.2.0",
+            "python-version": "3.10",
+            "payu-version": "2.0.0",
+        },
+    }
+
+
+def test_parse_ci_config(sample_config, tmp_path):
+    config_file = tmp_path / "ci.json"
+    with open(config_file, "w") as f:
+        json.dump(sample_config, f)
+
+    result = parse_ci_config("reproducibility", "release-1deg_jra55_ryf", config_file)
+    assert result == {
+        "model-config-tests-version": "1.2.0",
+        "python-version": "3.10",
+        "markers": "repro or repro_slow",
+        "payu-version": "2.0.0",
+    }
+
+    result = parse_ci_config("reproducibility", "dev-something", config_file)
+    assert result == {
+        "model-config-tests-version": "1.2.0",
+        "python-version": "3.10",
+        "markers": "default-repro",
+        "payu-version": "dev",
+    }


### PR DESCRIPTION
Support regex matching for tag/branches when parsing `config/ci.json` file. This is to allow using regex `dev-.*` patterns to specify test configuration for all dev branches, e.g. 
```json
{
    # ...
    "qa": {
        "dev-.*": { 
            "markers": "dev_config"
        },
        "default": {
           "markers": "config or dev_config"
       }
   },
   "default": { 
        # ....
    }
}
```

I added a python script for parsing the file so I could just use the standard python regex library for string matching. This meant it was also easier to add tests.

The order for finding a key's (e.g. "markers") value now is: 
 1. Exact match for branch/tag name in test type (e.g. `qa`)
 2. Then first branch name matched with regex pattern for branch name in test type. This means a top-down ordering of regex patterns so would require more specific branch regex to be higher up in the list, e.g. `dev-1deg-.*` before `dev-.*`
 3. Default for the test type (e.g. 'qa') 
 4. Top-level default

To avoid the composite action modifying the caller workflow environment, I've set `update-environment: false` in `setup-python` action, and called the python executable directly using the output of the action (see https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-update-environment-flag).

Similarly to avoid checking out the `model-config-tests` repository to obtain the `parse-file.py` file of the correct version, I am using `github.action_path` to access the files in the `.github/actions/pares-ci-config` directory (see https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context).

References #99