### PR TITLE
Fix versioneer tag prefix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ VCS = "git"
 style = "pep440"
 versionfile_source = "src/model_config_tests/_version.py"
 versionfile_build = "model_config_tests/_version.py"
-tag_prefix = ""
+tag_prefix = "v"
 parentdir_prefix = "model_config_tests-"
 
 [tool.coverage.run]

--- a/src/model_config_tests/_version.py
+++ b/src/model_config_tests/_version.py
@@ -51,7 +51,7 @@ def get_config() -> VersioneerConfig:
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = ""
+    cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "model_config_tests-"
     cfg.versionfile_source = "src/model_config_tests/_version.py"
     cfg.verbose = False


### PR DESCRIPTION
Versioneer was setup last week in this PR: https://github.com/ACCESS-NRI/model-config-tests/pull/108. Though this repository prefixes tags with `v`, e.g. `v0.0.11` so I've updated the `tag_prefix = "v"` in `pyproject.toml` and regenerated the versioneer files. 
