### PR TITLE
Support branch version for model-config-tests in test configuration

### DIFF
--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -184,7 +184,13 @@ jobs:
           cache-dependency-path: model-config-tests/pyproject.toml
 
       - name: Install model-config-tests
-        run: pip install model-config-tests=='${{ needs.config.outputs.qa-model-config-tests-version }}'
+        run: |
+          VERSION="${{ needs.config.outputs.qa-model-config-tests-version }}"
+          pip install "model-config-tests==${VERSION}" || {
+            echo "Failed to install model-config-tests==${VERSION} from PyPI"
+            echo "Attempting to install directly from Github repository with reference ${VERSION}"
+            pip install git+https://github.com/access-nri/model-config-tests.git@${VERSION}
+          }
 
       - name: Invoke Simple CI Pytests
         # We continue on error because we will let the checks generated in

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -153,7 +153,12 @@ jobs:
           source "${{ env.TEST_VENV_LOCATION }}/bin/activate"
 
           # Install model-config-tests
-          pip install model-config-tests==${{ inputs.model-config-tests-version }}
+          TEST_VERSION="${{ inputs.model-config-tests-version }}"
+          pip install "model-config-tests==${TEST_VERSION}" || {
+            echo "Failed to install model-config-tests==${TEST_VERSION} from PyPI"
+            echo "Attempting to install directly from Github repository with reference ${TEST_VERSION}"
+            pip install git+https://github.com/access-nri/model-config-tests.git@${TEST_VERSION}
+          }
 
           # The pytests in model-config-tests might fail in this command,
           # but that is okay. We still want to run the rest of the commands


### PR DESCRIPTION
To support setting `"model-config-tests-version": "main"` in `config/ci.json`, this PR adds some logic to attempt to install `model-config-tests` first from PyPI. Then if that fails, it attempts to install `model-config-tests` directly from Github, using the version as the reference. This means it will support git commits and other branch names if it's ever needed for testing.

Closes #109 