### PR TITLE
Update README.md with information of the model configuration file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,100 @@ D   (PR Target Branch)
 |/
 A   (Common Ancestor)
 ```
+
+### CI Configuration File
+
+Each model configuration repository requires a `config/ci.json`
+file for defining CI test configuration. This file specifies what scheduled tests to run, and what tests to run for a given git branch of tag and test type.
+
+#### Test types
+
+The different types of test are defined as:
+
+- `scheduled`: Scheduled monthly reproducibility tests run on NCI. The keys under these tests are released configuration tags to run the scheduled tests.
+- `reproducibility`: Reproducibility tests run as part of pull requests and are run on NCI. The keys under these tests represent the target branches into which pull requests are being merged. These are automatically run for pull requests from development (`dev-`) branches to released (`release-`) branches. These tests can also be triggered manually in a PR using the `!test repro` command.
+- `qa` - Quick quality assurance tests are run as part of pull requests and run locally on a GitHub Runner. The keys under these tests represent the target branches into which pull requests are being merged. These are run for any PR being merged into development or released branches.
+
+#### Test Configuration Settings
+
+The configuration properties needed to run the tests are:
+
+| Name | Type | Description |  Example |
+| ---- | ---- | ----------- | -------- |
+| markers | `string` | Markers used for the pytest checks, in the Python format | `checksum` |
+| model-config-tests-version | `string` | The version of the model-config-tests | `0.0.1` |
+| python-version | `string` | The python version used to create test virtual environment on GitHub hosted tests | `3.11.0` |
+| payu-version | `string` | The Payu version used to run the model | `1.1.5` |
+
+Pytest markers select what pytests to run in `model-config-tests`. Current markers include:
+
+- `checksum`: Reproducibility test that runs a model and compares checksums with a stored previous result.
+- `checksum_slow`: Slower reproducibility tests. These include repeating running a configuration from initial conditions to check it reproduces the same output, and checking restart reproducibility by comparing two shorter model runs with a longer model run.
+- `dev_config`: General configuration QA tests.
+- `config`: Configuration QA tests for released branches.
+
+There are also model-specific markers for configuration QA tests, e.g., `access_om2`, `access_esm1p5`, `access_om3` and `access_esm1p6`.
+
+To select a combination of tests, use the `or` keyword, e.g. `"markers": "dev_config or config"`.
+
+The Payu version is the module version loaded on NCI to build the base of the test virtual environment. To use the development Payu module which has all the latest changes in Payu repository, set `"payu-version": "dev"`.
+
+For development model configuration branches, it may be useful to use `main` branch of the `model-config-tests` repository. A git branch, tag, or commit of the `model-config-tests` repository can be used for `model-config-tests-version`, and the CI will install from Github if the package can't be installed from PyPI. Similarly, with the development Payu version, it is recommended to use released versions so the released configurations tests are stable.
+
+#### File Structure
+
+The schema for this file is found in [`ACCESS-NRI/schema`](https://github.com/ACCESS-NRI/schema).  As most of the tests use the same test and python versions, and similar markers, there are two levels of defaults. There's a default at the test type level which is useful for defining test markers - this selects certain pytests to run in `model-config-tests`. There is an outer global default, which is used if a property is not defined for a given branch/tag, and it is not defined for the test default. The [`parse-ci-config`](.github/actions/parse-ci-config/README.md) action applies this fall-back default logic.
+
+There is also support for using regex patterns for the git branches for `qa` and `reproducibility` tests, e.g.
+`dev-.*` will match all development branches. If there are multiple regex patterns, priority will be given to the order so more specific patterns should
+be higher in the list, e.g. `dev-1deg-.*` before `dev-.*`. Note that regex patterns are currently not supported for `scheduled` tests so every tag that requires a scheduled test needs to be defined.
+
+For example, given the following `config/ci.json` file:
+
+```json
+{
+    "$schema": "<https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/configuration/ci/2-0-0.json>",
+    "scheduled": {
+        "release-1deg_jra55_ryf-2.0": {},
+        "default": {
+            "markers": "checksum"
+        },
+    },
+    "reproducibility": {
+        "default": {
+            "markers": "checksum"
+        },
+        "dev-1deg_jra55do_ryf": {
+            "markers": "checksum or checksum_slow"
+        },
+        "release-1deg_jra55do_ryf": {
+            "markers": "checksum or checksum_slow"
+        },
+        "dev-example-branch": {
+            "payu-version": "dev",
+            "model-config-tests-version": "main"
+        },
+    },
+    "qa": {
+        "dev-.*": "dev_config",
+        "dev-example-branch": {
+            "model-config-tests-version": "main"
+        },
+        "default": {
+            "markers": "config or dev_config"
+        }
+    },
+    "default": {
+        "model-config-tests-version": "0.0.11",
+        "python-version": "3.11.0",
+        "payu-version": "1.1.6"
+    }
+}
+```
+
+The above configuration triggers monthly scheduled tests for `release-1deg_jra55_ryf-2.0` GitHub tag. This scheduled test will run with `checksum` test marker, and the top-level defaults for `model-config-tests-version`, `python-version` and `payu-version`.
+
+If a PR was being merged into a `release-1deg_jra55do_ryf` branch, the QA tests run on the GitHub runner would use the `config or dev_config` test markers and the repro tests on NCI, would select the `checksum or checksum_slow` tests.
+
+If a PR was being merged into a `dev-example-branch`, the QA tests that run automatically would use the `dev_config` tests and if repro tests were triggered manually, then it would use the `checksum` tests.
+For both test types, it would use the latest changes in the `model-config-tests` repository. For repro tests, it would use the `payu/dev` module on NCI for running the model.


### PR DESCRIPTION
Added description of `config/ci.json`. I think it makes the most sense to put this description in this repository so it can be easily updated and have links to this section from the `ACCESS-NRI/model-configs-template` repository.

I'll leave this draft for now as it references open PRs #113 and #111 for adding more flexibility to the configuration file.

Closes #107