### PR TITLE
test-repro.yml: Exit ssh session if test setup fails

### DIFF
--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -109,6 +109,9 @@ jobs:
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash<<'EOT'
 
+          # Immediately exit if any test setup fails
+          set -e
+
           # Remove base experiment (and everything else) if it exists
           if [ -d "${{ env.EXPERIMENT_LOCATION }}" ]; then
             rm -rf "${{ env.EXPERIMENT_LOCATION }}"


### PR DESCRIPTION
During the ssh session to gadi which runs the repro tests, if any of the test setup fails, e.g. loading `payu` modules or pip installing `model-config-tests`, it should exit immediately and report as a failed step. At the moment, I've just added a `set -e` at the start of the script which seems to work when testing on a separate test repository. 

