### PR TITLE
Skip config test checking UUID in `metadata.yaml` if `metadata.yaml`doesn't exist

### DIFF
--- a/src/model_config_tests/conftest.py
+++ b/src/model_config_tests/conftest.py
@@ -50,6 +50,13 @@ def metadata(control_path: Path):
 
 
 @pytest.fixture(scope="session")
+def skipif_no_metadata(control_path):
+    metadata_path = control_path / "metadata.yaml"
+    if not metadata_path.exists():
+        pytest.skip("No metadata.yaml file exists")
+
+
+@pytest.fixture(scope="session")
 def config(control_path: Path):
     """Read the config file in the control directory"""
     config_path = control_path / "config.yaml"

--- a/src/model_config_tests/qa/test_config.py
+++ b/src/model_config_tests/qa/test_config.py
@@ -212,10 +212,11 @@ class TestConfig:
                 "The target branch is a dev version and doesn't require a stable module location"
             )
 
+    @pytest.mark.usefixtures("skipif_no_metadata")
     def test_metadata_does_not_contain_UUID(self, metadata):
         assert "experiment_uuid" not in metadata, (
             "`experiment_uuid` should not be defined in metadata, "
-            + "as this is an configuration rather than an experiment. "
+            + "as this is a configuration rather than an experiment. "
         )
 
     def test_sync_is_not_enabled(self, config):


### PR DESCRIPTION
Closes #119 