### PR TITLE
Fix non existent label error in scheduled workflow

### DIFF
--- a/.github/workflows/config-schedule-1-ci.yml
+++ b/.github/workflows/config-schedule-1-ci.yml
@@ -10,15 +10,15 @@ jobs:
     name: Setup Tasks
     runs-on: ubuntu-latest
     outputs:
-      tags: ${{ steps.get-released-config.outputs.tags }}
+      refs: ${{ steps.get-scheduled-tests.outputs.refs }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: main
 
-      - name: Get all released configs
-        id: get-released-config
-        run: echo "tags=$(jq --compact-output --raw-output '.scheduled | del(.default) | keys' config/ci.json)" >> $GITHUB_OUTPUT
+      - name: Get all tag/branches of configs for scheduled tests
+        id: get-scheduled-tests
+        run: echo "refs=$(jq --compact-output --raw-output '.scheduled | del(.default) | keys' config/ci.json)" >> $GITHUB_OUTPUT
 
   repro-ci:
     # We use this reusable workflow with a matrix strategy rather than calling repro-ci.yml, as
@@ -28,10 +28,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config-tag: ${{ fromJson(needs.setup.outputs.tags) }}
+        config-ref: ${{ fromJson(needs.setup.outputs.refs) }}
     uses: ./.github/workflows/config-schedule-2-start.yml
     with:
-      config-tag: ${{ matrix.config-tag }}
+      config-ref: ${{ matrix.config-ref }}
     secrets: inherit
     permissions:
       checks: write

--- a/.github/workflows/config-schedule-1-ci.yml
+++ b/.github/workflows/config-schedule-1-ci.yml
@@ -19,16 +19,19 @@ jobs:
       - name: Get all tag/branches of configs for scheduled tests
         id: get-scheduled-tests
         run: |
-          # Pattern to exclude refs that include ? or * or [
-          exclude_pattern="[\\*\\?\\[]"
+          # Parse keys under scheduled and exclude the default configuration
+          scheduled_keys=$(jq --compact-output --raw-output '.scheduled | del(.default) | keys | .[]' config/ci.json)
 
-          # Filter out keys under scheduled that are not default and do not
-          # include some regex characters
-          refs=$(jq --compact-output --raw-output --arg pattern "$exclude_pattern" '
-            .scheduled | del(.default) | keys | map(select(test($pattern) | not))
-          ' config/ci.json)
+          # Parse the valid branches or tags in the git repository
+          valid_refs="["
+          for ref in $scheduled_keys; do
+            if [[ -n "$(git ls-remote --tags --branches origin "${ref}")" ]]; then
+              valid_refs="$valid_refs\"$ref\","
+            fi
+          done
 
-          echo "refs=$refs" >> $GITHUB_OUTPUT
+          # Remove trailing comma and close the square bracket
+          echo "refs=$( echo "${valid_refs%,}]" | jq -r 'tostring' )" >> $GITHUB_OUTPUT
 
   repro-ci:
     # We use this reusable workflow with a matrix strategy rather than calling repro-ci.yml, as

--- a/.github/workflows/config-schedule-1-ci.yml
+++ b/.github/workflows/config-schedule-1-ci.yml
@@ -18,7 +18,17 @@ jobs:
 
       - name: Get all tag/branches of configs for scheduled tests
         id: get-scheduled-tests
-        run: echo "refs=$(jq --compact-output --raw-output '.scheduled | del(.default) | keys' config/ci.json)" >> $GITHUB_OUTPUT
+        run: |
+          # Pattern to exclude refs that include ? or * or [
+          exclude_pattern="[\\*\\?\\[]"
+
+          # Filter out keys under scheduled that are not default and do not
+          # include some regex characters
+          refs=$(jq --compact-output --raw-output --arg pattern "$exclude_pattern" '
+            .scheduled | del(.default) | keys | map(select(test($pattern) | not))
+          ' config/ci.json)
+
+          echo "refs=$refs" >> $GITHUB_OUTPUT
 
   repro-ci:
     # We use this reusable workflow with a matrix strategy rather than calling repro-ci.yml, as

--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -2,10 +2,10 @@ name: Scheduled Checks - Branch Specific
 on:
   workflow_call:
     inputs:
-      config-tag:
+      config-ref:
         type: string
         required: true
-        description: Tag associated with a config branch that is used in the reproducibility run
+        description: Tag or branch of a configuration used for the scheduled checks
 jobs:
   config:
     name: Read CI Testing Configuration
@@ -33,7 +33,7 @@ jobs:
         uses: access-nri/model-config-tests/.github/actions/parse-ci-config@main
         with:
           check: scheduled
-          branch-or-tag: ${{ inputs.config-tag }}
+          branch-or-tag: ${{ inputs.config-ref }}
           config-filepath: "config/ci.json"
 
   repro-ci:
@@ -45,8 +45,8 @@ jobs:
     with:
       # FIXME: Make the environment name an input of some kind - what if we deploy to a different supercomputer?
       environment-name: Gadi
-      config-ref: ${{ inputs.config-tag }}
-      compared-config-ref: ${{ inputs.config-tag }}
+      config-ref: ${{ inputs.config-ref }}
+      compared-config-ref: ${{ inputs.config-ref }}
       test-markers: ${{ needs.config.outputs.markers }}
       model-config-tests-version: ${{ needs.config.outputs.model-config-tests-version }}
       payu-version: ${{ needs.config.outputs.payu-version }}
@@ -74,7 +74,7 @@ jobs:
           model=${config%-*}
           echo "model=$model" >> $GITHUB_OUTPUT
           echo "model-url=https://github.com/ACCESS-NRI/$model" >> $GITHUB_OUTPUT
-          echo "tag-url=https://github.com/ACCESS-NRI/$config/releases/tag/${{ inputs.config-tag }}" >> GITHUB_OUTPUT
+          echo "ref-url=${{ github.server_url }}/${{ github.repository }}/tree/${{ inputs.config-ref }}" >> $GITHUB_OUTPUT
           echo "run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
 
           cat $GITHUB_OUTPUT
@@ -88,11 +88,11 @@ jobs:
 
             Model: `${{ steps.variables.outputs.model }}`, found here: ${{ steps.variables.outputs.model-url }}
             Config Repo: `${{ steps.variables.outputs.config }}`, found here: ${{ steps.variables.outputs.config-url }}
-            Config Tag Tested for Reproducibility: `${{ inputs.config-tag }}`, found here: ${{ steps.variables.outputs.tag-url }}
+            Config Ref Tested for Reproducibility: `${{ inputs.config-ref }}`, found here: ${{ steps.variables.outputs.ref-url }}
             Failed Run Log: ${{ steps.variables.outputs.run-url }}
             Experiment Location (Gadi): `${{ needs.repro-ci.outputs.experiment-location }}`
             Checksums created: In the `testing/checksum` directory of ${{ needs.repro-ci.outputs.artifact-url }}
-            Checksums compared against: ${{ format('{0}/{1}/tree/{2}/testing/checksum', github.server_url, github.repository, inputs.config-tag) }}
+            Checksums compared against: ${{ format('{0}/{1}/tree/{2}/testing/checksum', github.server_url, github.repository, inputs.config-ref) }}
 
             Tagging @ACCESS-NRI/model-release
         run: |
@@ -101,6 +101,6 @@ jobs:
           gh label create 'priority:blocker' --color B60205 || true
 
           gh issue create \
-            --title 'Scheduled Repro Check Failed for Config `${{ inputs.config-tag }}`' \
+            --title 'Scheduled Repro Check Failed for Config `${{ inputs.config-ref }}`' \
             --label "type:repro-fail,priority:blocker" \
             --body '${{ env.BODY }}'

--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -84,7 +84,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           BODY: |
-            There was a failure of a monthly reproducibility check on `${{ github.repository }}`.
+            There was a failure of the scheduled reproducibility check on `${{ github.repository }}`.
 
             Model: `${{ steps.variables.outputs.model }}`, found here: ${{ steps.variables.outputs.model-url }}
             Config Repo: `${{ steps.variables.outputs.config }}`, found here: ${{ steps.variables.outputs.config-url }}
@@ -96,6 +96,10 @@ jobs:
 
             Tagging @ACCESS-NRI/model-release
         run: |
+          # Create tags for the issue if they don't already exist
+          gh label create 'type:repro-fail' --description 'Repro check failure' --color 000000 || true
+          gh label create 'priority:blocker' --color B60205 || true
+
           gh issue create \
             --title 'Scheduled Repro Check Failed for Config `${{ inputs.config-tag }}`' \
             --label "type:repro-fail,priority:blocker" \


### PR DESCRIPTION
This PR:
- creates labels if label doesn't already exist  before creating an issue for a failed scheduled repro run (to avoid errors when creating issues - see this failed workflow run https://github.com/ACCESS-NRI/access-om3-configs/actions/runs/13621679135/job/38072666505)
- as scheduled tests can be run with branches, I've updated the internal input/outputs to use `config-ref` rather than `config-tag` and changed one of the urls. 

Closes #125