### PR TITLE
Add Gadi.spack.location download url to QA executable test

### DIFF
--- a/tests/qa/test_test_config.py
+++ b/tests/qa/test_test_config.py
@@ -84,6 +84,6 @@ def test_get_spack_location_file_no_spack_location():
     or Gadi.spack.location file is not found in the release artefact
     """
     with patch("requests.get", side_effect=mock_request_get):
-        error_msg = r"Failed to download a spack.location .*"
+        error_msg = r"Failed to download a spack\.location .*"
         with pytest.raises(AssertionError, match=error_msg):
             get_spack_location_file("fake-repo", "fake-version")


### PR DESCRIPTION
This PR attempts to download a `Gadi.spack.location` file in the release artefact, if a `spack.location` doesn't exist. This is to support model releases deployed to Gadi using `ACCESS-NRI/build-cd` v4. 

I think it'll need a rethink once configurations are developed to run on other HPCs

Closes #132