### PR TITLE
Add test-specific repro test markers

### DIFF
--- a/src/model_config_tests/conftest.py
+++ b/src/model_config_tests/conftest.py
@@ -122,6 +122,15 @@ def pytest_configure(config):
         "markers", "checksum_slow: mark tests as slow reproducibility tests"
     )
     config.addinivalue_line(
+        "markers", "repro_historical: mark tests as historical reproducibility test"
+    )
+    config.addinivalue_line(
+        "markers", "repro_repeat: mark tests as repeat reproducibility test"
+    )
+    config.addinivalue_line(
+        "markers", "repro_restart: mark tests as restart reproducibility test"
+    )
+    config.addinivalue_line(
         "markers",
         "config: mark as configuration tests for release branches in quick QA CI checks",
     )

--- a/src/model_config_tests/conftest.py
+++ b/src/model_config_tests/conftest.py
@@ -116,20 +116,18 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line(
-        "markers", "checksum: mark tests to run as part of reproducibility CI tests"
+        "markers", "repro: mark tests to run as part of reproducibility tests"
     )
     config.addinivalue_line(
-        "markers", "checksum_slow: mark tests as slow reproducibility tests"
+        "markers", "repro_historical: mark tests that check historical reproducibility"
     )
     config.addinivalue_line(
-        "markers", "repro_historical: mark tests as historical reproducibility test"
+        "markers", "repro_repeat: mark tests that check repeat reproducibility"
     )
     config.addinivalue_line(
-        "markers", "repro_repeat: mark tests as repeat reproducibility test"
+        "markers", "repro_restart: mark tests that check restart reproducibility"
     )
-    config.addinivalue_line(
-        "markers", "repro_restart: mark tests as restart reproducibility test"
-    )
+    config.addinivalue_line("markers", "slow: mark tests that are slow to run")
     config.addinivalue_line(
         "markers",
         "config: mark as configuration tests for release branches in quick QA CI checks",

--- a/src/model_config_tests/test_bit_reproducibility.py
+++ b/src/model_config_tests/test_bit_reproducibility.py
@@ -47,7 +47,7 @@ def read_historical_checksums(
 
 class TestBitReproducibility:
 
-    @pytest.mark.checksum
+    @pytest.mark.repro
     @pytest.mark.repro_historical
     def test_bit_repro_historical(
         self,
@@ -133,8 +133,9 @@ class TestBitReproducibility:
             hist_checksums == checksums
         ), f"Checksums were not equal. The new checksums have been written to {checksum_output_file}."
 
-    @pytest.mark.checksum_slow
+    @pytest.mark.repro
     @pytest.mark.repro_repeat
+    @pytest.mark.slow
     def test_bit_repro_repeat(self, output_path: Path, control_path: Path):
         """
         Test that a run has same checksums when ran twice
@@ -156,8 +157,9 @@ class TestBitReproducibility:
 
         assert produced == expected
 
-    @pytest.mark.checksum_slow
+    @pytest.mark.repro
     @pytest.mark.repro_restart
+    @pytest.mark.slow
     def test_restart_repro(self, output_path: Path, control_path: Path):
         """
         Test that a run reproduces across restarts.

--- a/src/model_config_tests/test_bit_reproducibility.py
+++ b/src/model_config_tests/test_bit_reproducibility.py
@@ -48,6 +48,7 @@ def read_historical_checksums(
 class TestBitReproducibility:
 
     @pytest.mark.checksum
+    @pytest.mark.repro_historical
     def test_bit_repro_historical(
         self,
         output_path: Path,
@@ -133,6 +134,7 @@ class TestBitReproducibility:
         ), f"Checksums were not equal. The new checksums have been written to {checksum_output_file}."
 
     @pytest.mark.checksum_slow
+    @pytest.mark.repro_repeat
     def test_bit_repro_repeat(self, output_path: Path, control_path: Path):
         """
         Test that a run has same checksums when ran twice
@@ -155,6 +157,7 @@ class TestBitReproducibility:
         assert produced == expected
 
     @pytest.mark.checksum_slow
+    @pytest.mark.repro_restart
     def test_restart_repro(self, output_path: Path, control_path: Path):
         """
         Test that a run reproduces across restarts.


### PR DESCRIPTION
This PR adds some test-specific markers to the reproducibility tests to allow finer-grain control over which repro tests are run.

Closes #136