### PR TITLE
`!test repro commit`: Only commit if checksums differ to the ones on the branch

### DIFF
--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -313,7 +313,7 @@ jobs:
 
           if [ -z "$(git status --porcelain)" ]; then  # If there are no added files
             echo "::warning::Attempting to add the changed checksums failed as they were identical to the existing ones on the PR branch. A previous commit must have updated them already, and they match."
-            continue
+            exit 0
           fi
 
           git commit -m "Updated checksums as part of ${{ env.RUN_URL }}"

--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -246,7 +246,7 @@ jobs:
             - `${{ needs.prepare-command.outputs.config-ref }}` (checksums created using commit ${{ env.CONFIG_REF_URL }}), against
             - `${{ needs.prepare-command.outputs.compared-config-ref }}` (checksums in commit ${{ env.COMPARED_CONFIG_REF_URL }})
 
-            ${{ (needs.prepare-command.outputs.commit-requested == 'true' && needs.repro-ci.outputs.result == 'fail') && ':wrench: The checksums will be committed to this PR, as they differ.' || '' }}
+            ${{ (needs.prepare-command.outputs.commit-requested == 'true' && needs.repro-ci.outputs.result == 'fail') && ':wrench: The new checksums will be committed to this PR, if they differ from what is on this branch.' || '' }}
 
             <details>
             <summary> Further information</summary>
@@ -310,6 +310,12 @@ jobs:
       - name: Commit and Push Updates
         run: |
           git add .
+
+          if [ -z "$(git status --porcelain)" ]; then  # If there are no added files
+            echo "::warning::Attempting to add the changed checksums failed as they were identical to the existing ones on the PR branch. A previous commit must have updated them already, and they match."
+            continue
+          fi
+
           git commit -m "Updated checksums as part of ${{ env.RUN_URL }}"
           git push
 


### PR DESCRIPTION
Closes #138

## Background

If an earlier commit in a PR branch updates the checksums, and a later `!test repro commit` command finds that the base branch checksums differ, it will attempt to commit the new checksums. If these new checksums are actually identical to an earlier invocation of `!test repro commit` on the branch, it will fail to commit and push the changes. 

This PR checks that changes are actually added before committing and pushing. 

## This PR

In this PR:

* Only commit and push if there are actually checksums to add on this branch
* Update the repro result comment

## Testing

Tested the `git status --porcelain` (and indeed the whole step) locally to verify it is what we want. The `--porcelain` bit essentially makes the output machine-readable and never changes between versions of `git`, making it useful for scripts. 
