### PR TITLE
Run QA checks for bot commits

### DIFF
--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -153,9 +153,7 @@ jobs:
     # Run quick, non-HPC tests on the runner.
     name: QA CI Checks
     needs:
-      - commit-check
       - config
-    if: needs.commit-check.outputs.authorship != vars.GH_ACTIONS_BOT_GIT_USER_NAME
     runs-on: ubuntu-latest
     permissions:
       checks: write


### PR DESCRIPTION
Closes #141

## Background

Bot commits don't do QA checks, while regular commits do. This might confuse users because they will get a passing check rollup where they expected a failing one, because the QA checks fail in an earlier commit, and "pass" (i.e., are skipped) in a later bot one. 

## In this PR

* Remove the `commit-check` dependent job for `qa-ci`
