### PR TITLE
CD.yml: Update pypa/gh-action-pypi-publish to v1.12.4

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -47,4 +47,4 @@ jobs:
           path: dist
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf # v1.8.11
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4


### PR DESCRIPTION
Update version `pypa/gh-action-pypi-publish` so it supports the newer versions of twine (see related issue: https://github.com/pypa/gh-action-pypi-publish/issues/351)

Closes #151 