### PR TITLE
Update repro test markers and test names

### DIFF
--- a/src/model_config_tests/conftest.py
+++ b/src/model_config_tests/conftest.py
@@ -122,14 +122,14 @@ def pytest_configure(config):
         "markers", "repro_historical: mark tests that check historical reproducibility"
     )
     config.addinivalue_line(
-        "markers", "repro_repeat: mark tests that check repeat reproducibility"
+        "markers", "repro_determinism: mark tests that check determinism"
     )
     config.addinivalue_line(
         "markers", "repro_restart: mark tests that check restart reproducibility"
     )
     config.addinivalue_line(
         "markers",
-        "repro_restart_repeat: mark tests that check restart reproducibility with repeated runs",
+        "repro_determinism_restart: mark tests that check determinism restart",
     )
     config.addinivalue_line("markers", "slow: mark tests that are slow to run")
     config.addinivalue_line(

--- a/src/model_config_tests/test_bit_reproducibility.py
+++ b/src/model_config_tests/test_bit_reproducibility.py
@@ -156,7 +156,7 @@ class TestBitReproducibility:
             EXP_DEFAULT_RUNTIME: {"n_runs": 1},
         }
     )
-    def test_bit_repro_historical(
+    def test_repro_historical(
         self,
         output_path: Path,
         control_path: Path,
@@ -164,7 +164,9 @@ class TestBitReproducibility:
         checksum_path: Optional[Path],
     ):
         """
-        Test that a run reproduces historical checksums
+        Historical reproducibility test that confirms results from a model
+        run match a stored previous result. Any generated results are
+        added to a "checksum" subdirectory in the output directory.
 
         Parameters
         ----------
@@ -225,7 +227,7 @@ class TestBitReproducibility:
         ), f"Checksums were not equal. The new checksums have been written to {checksum_output_file}."
 
     @pytest.mark.repro
-    @pytest.mark.repro_repeat
+    @pytest.mark.repro_determinism
     @pytest.mark.slow
     @pytest.mark.experiments(
         {
@@ -233,9 +235,10 @@ class TestBitReproducibility:
             EXP_1D_RUNTIME_REPEAT: {"n_runs": 1, "model_runtime": DAY_IN_SECONDS},
         }
     )
-    def test_bit_repro_repeat(self, experiments: Experiments):
+    def test_repro_determinism(self, experiments: Experiments):
         """
-        Test that a run has same checksums when ran twice
+        Determinism test that confirms repeated model runs for 1 day
+        give the same results
         """
         experiments.check_experiments([EXP_1D_RUNTIME, EXP_1D_RUNTIME_REPEAT])
         exp_1d_runtime = experiments.get_experiment(EXP_1D_RUNTIME)
@@ -259,9 +262,11 @@ class TestBitReproducibility:
             EXP_2D_RUNTIME: {"n_runs": 1, "model_runtime": 2 * DAY_IN_SECONDS},
         }
     )
-    def test_restart_repro(self, output_path: Path, experiments: Experiments):
+    def test_repro_restart(self, output_path: Path, experiments: Experiments):
         """
-        Test that a run reproduces across restarts.
+        Restart reproducibility test that confirms two short consecutive
+        1-day model runs give the same results as a longer single 2-day model
+        run.
         """
         # Get experiments with 2x1 day and 2 day runtimes
         experiments.check_experiments([EXP_1D_RUNTIME, EXP_2D_RUNTIME])
@@ -293,17 +298,17 @@ class TestBitReproducibility:
 
         assert matching_checksums
 
-    @pytest.mark.repro_restart_repeat
+    @pytest.mark.repro_determinism_restart
     @pytest.mark.experiments(
         {
             EXP_1D_RUNTIME: {"n_runs": 2, "model_runtime": DAY_IN_SECONDS},
             EXP_1D_RUNTIME_REPEAT: {"n_runs": 2, "model_runtime": DAY_IN_SECONDS},
         }
     )
-    def test_restart_repro_repeat(self, experiments: Experiments):
+    def test_repro_determinism_restart(self, experiments: Experiments):
         """
-        Test that when a model is run twice for two runs
-        have the same checksums
+        Determinism test that confirms repeated experiments with two
+        consecutive 1-day model runs give the same results
         """
         experiments.check_experiments([EXP_1D_RUNTIME, EXP_1D_RUNTIME_REPEAT])
         exp_1d_runtime = experiments.get_experiment(EXP_1D_RUNTIME)

--- a/tests/test_test_bit_reproducibility.py
+++ b/tests/test_test_bit_reproducibility.py
@@ -247,11 +247,11 @@ class CommonTestHelper:
                 raise ValueError(f"Unrecognised model: {self.model_name}")
 
 
-def test_test_bit_repro_historical_access_checksums_saved_on_config(tmp_dir):
+def test_test_repro_historical_access_checksums_saved_on_config(tmp_dir):
     """Check the default settings for checksum path (saved on the
     configuration under testing/checksum), and the default for control
     directory fixture (use current working directory of subprocess call)"""
-    test_name = "test_bit_repro_historical"
+    test_name = "test_repro_historical"
     exp_name = "exp_default_runtime"
     model_name = "access"
 
@@ -289,10 +289,10 @@ def test_test_bit_repro_historical_access_checksums_saved_on_config(tmp_dir):
     assert result.returncode == 0
 
 
-def test_test_bit_repro_historical_access_no_reference_checksums(tmp_dir):
+def test_test_repro_historical_access_no_reference_checksums(tmp_dir):
     """Check when a reference file for checksums does not exist, that
     checksums from the output are written out"""
-    test_name = "test_bit_repro_historical"
+    test_name = "test_repro_historical"
     exp_name = "exp_default_runtime"
     model_name = "access"
 
@@ -318,10 +318,10 @@ def test_test_bit_repro_historical_access_no_reference_checksums(tmp_dir):
     check_checksum(helper.output_path, checksum_path, helper.model_name)
 
 
-def test_test_bit_repro_historical_access_no_model_output(tmp_dir):
+def test_test_repro_historical_access_no_model_output(tmp_dir):
     """Check when a test exits, that there are no checksums in the output
     directory- similar to when payu run exits with an error"""
-    test_name = "test_bit_repro_historical"
+    test_name = "test_repro_historical"
     exp_name = "exp_default_runtime"
     model_name = "access"
 
@@ -358,11 +358,11 @@ def test_test_bit_repro_historical_access_no_model_output(tmp_dir):
     ],
 )
 @pytest.mark.parametrize("fail", [False, True])
-def test_test_bit_repro_historical(tmp_dir, model_name, output_0, configuration, fail):
+def test_test_repro_historical(tmp_dir, model_name, output_0, configuration, fail):
     """Test ACCESS-OM classes with historical repro test with some mock
     output and configuration directory, optionally checking that things
     fail when the outputs are modified to give different checksums"""
-    test_name = "test_bit_repro_historical"
+    test_name = "test_repro_historical"
     exp_name = "exp_default_runtime"
 
     # Setup test Helper
@@ -414,7 +414,7 @@ def test_test_access_om3_ocean_model(tmp_dir):
     """Test that an error is thrown when the ocean model is not MOM. This should be moved into
     dedicated tests for experiment setup when they exist. See
     https://github.com/ACCESS-NRI/model-config-tests/issues/115"""
-    test_name = "test_bit_repro_historical"
+    test_name = "test_repro_historical"
     exp_name = "exp_default_runtime"
 
     # Setup test Helper


### PR DESCRIPTION
This updates marker and test names to hopefully make it more clear and consistent with README updates in #145 

Changes to the markers:
repro_repeat -> repro_determinism
repro_restart_repeat -> repro_determinism_restart

Changes to the test names to match the respective specific test marker:
test_bit_repro_historical -> test_repro_historical
test_bit_repro_repeat -> test_repro_determinism
test_restart_repro -> test_repro_restart
test_restart_repro_repeat -> test_repro_determinism_restart

Closes #156