### PR TITLE
accessom3: Change default run length to 6 hours

### DIFF
--- a/src/model_config_tests/models/accessom3.py
+++ b/src/model_config_tests/models/accessom3.py
@@ -8,11 +8,11 @@ import f90nml
 from netCDF4 import Dataset
 from payu.models.cesm_cmeps import Runconfig
 
-from model_config_tests.models.model import (
-    DEFAULT_RUNTIME_SECONDS,
-    SCHEMA_VERSION_1_0_0,
-    Model,
-)
+from model_config_tests.models.model import SCHEMA_VERSION_1_0_0, Model
+from model_config_tests.util import HOUR_IN_SECONDS
+
+# Default model runtime (6 hrs)
+DEFAULT_RUNTIME_SECONDS = 6 * HOUR_IN_SECONDS
 
 
 class AccessOm3(Model):


### PR DESCRIPTION
This PR changes the run length for ACCESS-OM3 repro tests to 6 hours

Closes #161 