### PR TITLE
Use days for ESM runtime

### DIFF
--- a/src/model_config_tests/models/accessesm1p5.py
+++ b/src/model_config_tests/models/accessesm1p5.py
@@ -61,12 +61,15 @@ class AccessEsm1p5(Model):
             seconds % DAY_IN_SECONDS == 0
         ), "Only days are supported in payu UM driver"
 
+        # ESM1.5/1.6 requires runtime in years, months, days
+        days = seconds / DAY_IN_SECONDS
+
         # Set runtime in config.yaml
         runtime_config = {
             "years": years,
             "months": months,
-            "days": 0,
-            "seconds": seconds,
+            "days": days,
+            "seconds": 0,
         }
         if "calendar" in doc:
             doc["calendar"]["runtime"] = runtime_config

--- a/tests/config_tests/test_test_bit_reproducibility.py
+++ b/tests/config_tests/test_test_bit_reproducibility.py
@@ -24,6 +24,7 @@ from model_config_tests.models.accessesm1p5 import (
 )
 from model_config_tests.models.accessom2 import DEFAULT_RUNTIME_SECONDS as OM2_RUNTIME
 from model_config_tests.models.accessom3 import DEFAULT_RUNTIME_SECONDS as OM3_RUNTIME
+from model_config_tests.util import DAY_IN_SECONDS
 
 
 def exp_test_helper_factory(*args, **kwargs):
@@ -457,8 +458,8 @@ def check_runtime(control_path, model_name):
         assert test_config["calendar"]["runtime"] == {
             "years": 0,
             "months": 0,
-            "days": 0,
-            "seconds": ESM_RUNTIME,
+            "days": ESM_RUNTIME / DAY_IN_SECONDS,
+            "seconds": 0,
         }
     elif model_name == "access-om2":
         with open(control_path / "accessom2.nml") as f:


### PR DESCRIPTION
Closes #163. Sets the ESM1.5/1.6 runtime using smallest unit "days". This is for compatibility with the payu driver, which only uses the `years`, `months` and `days` options to set the runtime.
