### PR TITLE
Add pytest error result to test-repro workflow

### DIFF
--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -232,6 +232,8 @@ jobs:
     steps:
       - name: Comment result
         env:
+          POTENTIAL_ERROR: |-
+            ${{ needs.repro-ci.outputs.result == 'error' && format(':warning: The Bitwise Reproducibility Check Had Errors - Check {0} :warning:', env.RUN_URL) || '' }}
           RESULT: |-
             ${{ needs.repro-ci.outputs.result == 'pass' && ':white_check_mark: The Bitwise Reproducibility Check Succeeded :white_check_mark:' || ':x: The Bitwise Reproducibility Check Failed :x:' }}
           CONFIG_REF_URL: '[${{ needs.prepare-command.outputs.config-short-hash }}](${{ github.server_url}}/${{ github.repository }}/tree/${{ needs.prepare-command.outputs.config-hash }})'
@@ -239,6 +241,7 @@ jobs:
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
+            ${{ env.POTENTIAL_ERROR }}
             ${{ env.RESULT }}
 
             When comparing:

--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -281,6 +281,7 @@ jobs:
     permissions:
       pull-requests: write
     env:
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       COMPARED_TAG: ${{ needs.config.outputs.compared-config-tag }}
       COMPARED_CHECKSUM_STRING: ${{ needs.config.outputs.compared-config-tag != '' && format('The checksums compared against are found here {0}/{1}/tree/{2}/testing/checksum', github.server_url, github.repository, needs.config.outputs.compared-config-tag) || '' }}
     steps:
@@ -310,6 +311,26 @@ jobs:
           comment: |
             :x: The Bitwise Reproducibility check failed ${{ env.COMPARED_TAG != '' && format('when comparing against `{0}`', env.COMPARED_TAG) || 'as there is no earlier checksum to compare against' }} :x:
             You must bump the major version of this configuration - to bump the version, comment `!bump major`or modify the `version` in `metadata.yaml`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
+
+            <details>
+            <summary> Further information</summary>
+
+            The experiment can be found on Gadi at `${{ needs.repro-ci.outputs.experiment-location }}`, and the test results at ${{ needs.repro-ci.outputs.check-run-url }}.
+
+            The checksums generated in this PR are found in the `testing/checksum` directory of ${{ needs.repro-ci.outputs.artifact-url }}.
+
+            ${{ env.COMPARED_CHECKSUM_STRING }}
+
+            </details>
+
+      - name: Error Repro Comment
+        if: needs.repro-ci.outputs.result == 'error'
+        uses: access-nri/actions/.github/actions/pr-comment@main
+        with:
+          comment: |
+            :warning: The Bitwise Reproducibility Check Had Errors - Check Test Results :warning:
+
+            The workflow run can be found at ${{ env.RUN_URL }}.
 
             <details>
             <summary> Further information</summary>

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -40,7 +40,7 @@ on:
         value: ${{ jobs.check-repro.outputs.result }}
         description: |
           Result of the repro check.
-          Output is `pass` if `inputs.config-ref` is bit-reproducible with `inputs.compared-config-ref`, `fail` otherwise
+          Output is `pass` if `inputs.config-ref` is bit-reproducible with `inputs.compared-config-ref`, `fail` if not, and `error` otherwise.
       check-run-url:
         value: ${{ jobs.check-repro.outputs.check-run-url }}
         description: URL to the parsed test results
@@ -255,7 +255,9 @@ jobs:
         run: |
           echo "check-url=${{ fromJson(steps.tests.outputs.json).check_url }}" >> $GITHUB_OUTPUT
 
-          if (( ${{ fromJson(steps.tests.outputs.json).stats.tests_fail }} > 0 )); then
+          if (( ${{ fromJson(steps.tests.outputs.json).stats.tests_error }} > 0 )); then
+            echo "result=error" >> $GITHUB_OUTPUT
+          elif (( ${{ fromJson(steps.tests.outputs.json).stats.tests_fail }} > 0 )); then
             echo "result=fail" >> $GITHUB_OUTPUT
           else
             echo "result=pass" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Closes #166

## Background

Tests erroring out is not captured by the `test-repro` workflow. This means that if there are errors in the tests (not failures) they are treated as a not-failures in the comment, and therefore a success. 

More detail in the linked issue. 

This PR adds an `error` state to the `outputs.result` of `test=repro`, and comments that reflect this. 

## The PR

- **test-repro: Add new result output state `error` for when tests error out, rather than treating it as `pass`**
- **Update comments to reference a potential error state**
