### PR TITLE
Add netCDF4 as a explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "ruamel.yaml >=0.18.5",
     "jsonschema >=4.21.1",
     "payu >=1.1.3",
-    "pytest-sugar"
+    "pytest-sugar",
+    "netCDF4"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Previously `netCDF4` was imported in an old version of the `yamanifest` dependency. This PR add `netCDF4` import explicitly as it's being imported directly in the project code.

Closes #168