### PR TITLE
Only Do Bump Check if Target Branch `metadata.yaml` Exists

### DIFF
--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -257,8 +257,12 @@ jobs:
           path: source
 
       - name: Modification Check
-        # If the PR branch version is different to the target branch (but isn't null or empty) then allow merging
+        # If the PR branch version is different to the target branch (but isn't null, empty or doesn't exist) then allow merging
         run: |
+          if [[ ! -f ./target/metadata.yaml ]]; then
+            echo "::notice::There is no metadata.yaml on the target branch, skipping modification check"
+          fi
+
           target=$(yq e '.version' ./target/metadata.yaml)
           source=$(yq e '.version' ./source/metadata.yaml)
 


### PR DESCRIPTION
Closes #171

## Background

In the linked issue, we have a run where the `release-*` branch doesn't have a `metadata.yaml`, which errors out the bump check. This shouldn't be an error, as it is perfectly valid for a new `release-*` branch to not have it - that is what the PR from `dev-*` to `release-*` adds!


## The PR

- Skip the bump check if the `metadata.yaml` doesn't exist on the target branch
