### PR TITLE
Clean up repro CI test outputs

### DIFF
--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -209,7 +209,8 @@ jobs:
     if: needs.prepare-command.outputs.test-type == 'repro'
     uses: access-nri/model-config-tests/.github/workflows/test-repro.yml@main
     with:
-      config-ref: ${{ needs.prepare-command.outputs.config-hash }}
+      config-hash: ${{ needs.prepare-command.outputs.config-hash }}
+      config-ref: ${{ needs.prepare-command.outputs.config-ref }}
       compared-config-ref: ${{ needs.prepare-command.outputs.compared-config-hash }}
       environment-name: ${{ needs.prepare-command.outputs.environment-name }}
       payu-version: ${{ needs.ci-config.outputs.payu-version }}

--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -225,6 +225,7 @@ jobs:
     with:
       # FIXME: Make the environment name an input of some kind - what if we deploy to a different supercomputer?
       environment-name: Gadi
+      config-hash: ${{ github.sha }}
       config-ref: ${{ github.head_ref }}
       compared-config-ref: ${{ needs.config.outputs.compared-config-tag }}
       test-markers: ${{ needs.config.outputs.repro-markers }}

--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -14,6 +14,7 @@ jobs:
       markers: ${{ steps.scheduled-config.outputs.markers }}
       payu-version: ${{ steps.scheduled-config.outputs.payu-version }}
       model-config-tests-version: ${{ steps.scheduled-config.outputs.model-config-tests-version }}
+      config-hash: ${{ steps.config-hash.outputs.config-hash }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -36,6 +37,12 @@ jobs:
           branch-or-tag: ${{ inputs.config-ref }}
           config-filepath: "config/ci.json"
 
+      - name: Set config hash
+        id: config-hash
+        run: |
+          # Find latest commit hash for the given config branch or tag
+          config_hash=$(git rev-parse ${{ inputs.config-ref }})
+
   repro-ci:
     # Run the given config on the deployment Github Environment (`environment-name`) and upload
     # the test results and checksum.
@@ -45,6 +52,7 @@ jobs:
     with:
       # FIXME: Make the environment name an input of some kind - what if we deploy to a different supercomputer?
       environment-name: Gadi
+      config-hash: ${{ needs.config.outputs.config-hash }}
       config-ref: ${{ inputs.config-ref }}
       compared-config-ref: ${{ inputs.config-ref }}
       test-markers: ${{ needs.config.outputs.markers }}
@@ -59,6 +67,7 @@ jobs:
     name: Failed Reproduction Notifier
     needs:
       - repro-ci
+      - config
     if: failure() || needs.repro-ci.outputs.result == 'fail'
     runs-on: ubuntu-latest
     permissions:
@@ -74,7 +83,7 @@ jobs:
           model=${config%-*}
           echo "model=$model" >> $GITHUB_OUTPUT
           echo "model-url=https://github.com/ACCESS-NRI/$model" >> $GITHUB_OUTPUT
-          echo "ref-url=${{ github.server_url }}/${{ github.repository }}/tree/${{ inputs.config-ref }}" >> $GITHUB_OUTPUT
+          echo "ref-url=${{ github.server_url }}/${{ github.repository }}/tree/${{ needs.config.outputs.config-hash }}" >> $GITHUB_OUTPUT
           echo "run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
 
           cat $GITHUB_OUTPUT
@@ -92,7 +101,7 @@ jobs:
             Failed Run Log: ${{ steps.variables.outputs.run-url }}
             Experiment Location (Gadi): `${{ needs.repro-ci.outputs.experiment-location }}`
             Checksums created: In the `testing/checksum` directory of ${{ needs.repro-ci.outputs.artifact-url }}
-            Checksums compared against: ${{ format('{0}/{1}/tree/{2}/testing/checksum', github.server_url, github.repository, inputs.config-ref) }}
+            Checksums compared against: ${{ steps.variables.outputs.ref-url }}/testing/checksum
 
             Tagging @ACCESS-NRI/model-release
         run: |

--- a/.github/workflows/generate-checksums.yml
+++ b/.github/workflows/generate-checksums.yml
@@ -49,6 +49,7 @@ jobs:
       payu-version: ${{ steps.repro-config.outputs.payu-version }}
       model-config-tests-version: ${{ steps.repro-config.outputs.model-config-tests-version }}
       checksum-tag: ${{ steps.checksum-tag.outputs.checksum-tag }}
+      config-hash: ${{ steps.config-hash.outputs.config-hash }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -70,6 +71,12 @@ jobs:
           check: reproducibility
           branch-or-tag: ${{ inputs.config-branch-name }}
           config-filepath: "config/ci.json"
+
+      - name: Set config hash
+        id: config-hash
+        run: |
+          # Find latest commit hash for the given config branch or tag
+          config_hash=$(git rev-parse ${{ inputs.config-branch-name }})
 
       - name: Set committed checksum tag
         if: inputs.commit-checksums
@@ -93,6 +100,7 @@ jobs:
       - log-inputs
     uses: access-nri/model-config-tests/.github/workflows/test-repro.yml@main
     with:
+      config-hash: ${{ needs.config.outputs.config-hash }}
       config-ref: ${{ inputs.config-branch-name }}
       environment-name: ${{ inputs.environment-name }}
       test-markers: ${{ inputs.test-markers }}

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -2,10 +2,14 @@ name: Repro Checks
 on:
   workflow_call:
     inputs:
+      config-hash:
+        type: string
+        required: false
+        description: A SHA commit of the associated config branch to use for the reproducibility run
       config-ref:
         type: string
         required: true
-        description: A commit or tag on an associated config branch to use for the reproducibility run
+        description: A branch or tag on an associated config branch to use for the reproducibility run
       compared-config-ref:
         type: string
         required: false
@@ -100,6 +104,13 @@ jobs:
             ${{ secrets.SSH_HOST_DATA }}
           private-key: ${{ secrets.SSH_KEY }}
 
+      - name: Set experiment location
+        run: |
+          # Check to add commit hash to the experiment location if provided
+          if [[ -n "${{ inputs.config-hash }}" ]]; then
+            echo "EXPERIMENT_LOCATION=${{ env.EXPERIMENT_LOCATION }}/${{ inputs.config-hash }}" >> $GITHUB_ENV
+          fi
+
       - name: Run configuration
         id: run
         env:
@@ -120,7 +131,11 @@ jobs:
 
           # Setup a base experiment
           git clone ${{ github.event.repository.clone_url }} "${{ env.BASE_EXPERIMENT_LOCATION }}"
-          git -C "${{ env.BASE_EXPERIMENT_LOCATION }}" checkout ${{ inputs.config-ref }}
+          if [ -n "${{ inputs.config-hash }}" ]; then
+            git -C "${{ env.BASE_EXPERIMENT_LOCATION }}" checkout ${{ inputs.config-hash }}
+          else
+            git -C "${{ env.BASE_EXPERIMENT_LOCATION }}" checkout ${{ inputs.config-ref }}
+          fi
           cd "${{ env.BASE_EXPERIMENT_LOCATION }}"
 
           # Setup a compared checksum (if it exists)
@@ -206,7 +221,12 @@ jobs:
 
       - name: Generate Test Output Artifact Name
         id: artifact
-        run: echo "name=${{ github.event.repository.name }}-${{ inputs.config-ref }}" >> $GITHUB_OUTPUT
+        run: |
+          if [ -n "${{ inputs.config-hash }}" ]; then
+            echo "name=${{ github.event.repository.name }}-${{ inputs.config-hash }}" >> $GITHUB_OUTPUT
+          else
+            echo "name=${{ github.event.repository.name }}-${{ inputs.config-ref }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Upload Test Output
         id: upload
@@ -262,3 +282,30 @@ jobs:
           else
             echo "result=pass" >> $GITHUB_OUTPUT
           fi
+
+  clean-up:
+    name: Clean up test outputs
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment-name }}
+    if: needs.check-repro.outputs.result != 'error'
+    needs:
+      - repro
+      - check-repro
+    steps:
+      - name: Setup SSH
+        id: ssh
+        uses: access-nri/actions/.github/actions/setup-ssh@main
+        with:
+          hosts: |
+            ${{ secrets.SSH_HOST }}
+          private-key: ${{ secrets.SSH_KEY }}
+
+      - name: Remove all test output except checksum
+        run: |
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash<<'EOT'
+          # Remove all test output directories except checksum
+          rm -rf "${{ needs.repro.outputs.experiment-location }}/base-experiment"
+          rm -rf "${{ needs.repro.outputs.experiment-location }}/compared"
+          rm -rf "${{ needs.repro.outputs.experiment-location }}/control"
+          rm -rf "${{ needs.repro.outputs.experiment-location }}/lab"
+          EOT

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       config-hash:
         type: string
-        required: false
+        required: true
         description: A SHA commit of the associated config branch to use for the reproducibility run
       config-ref:
         type: string
@@ -71,7 +71,7 @@ jobs:
       artifact-url: ${{ steps.upload.outputs.artifact-url }}
       experiment-location: ${{ steps.run.outputs.experiment-location }}
     env:
-      EXPERIMENT_LOCATION: ${{ vars.EXPERIMENTS_LOCATION }}/${{ github.event.repository.name }}/${{ inputs.config-ref }}
+      EXPERIMENT_LOCATION: ${{ vars.EXPERIMENTS_LOCATION }}/${{ github.event.repository.name }}/${{ inputs.config-ref }}/${{ inputs.config-hash }}
     steps:
       - name: Validate ${{ inputs.environment-name }} Variables
         run: |
@@ -104,13 +104,6 @@ jobs:
             ${{ secrets.SSH_HOST_DATA }}
           private-key: ${{ secrets.SSH_KEY }}
 
-      - name: Set experiment location
-        run: |
-          # Check to add commit hash to the experiment location if provided
-          if [[ -n "${{ inputs.config-hash }}" ]]; then
-            echo "EXPERIMENT_LOCATION=${{ env.EXPERIMENT_LOCATION }}/${{ inputs.config-hash }}" >> $GITHUB_ENV
-          fi
-
       - name: Run configuration
         id: run
         env:
@@ -131,11 +124,7 @@ jobs:
 
           # Setup a base experiment
           git clone ${{ github.event.repository.clone_url }} "${{ env.BASE_EXPERIMENT_LOCATION }}"
-          if [ -n "${{ inputs.config-hash }}" ]; then
-            git -C "${{ env.BASE_EXPERIMENT_LOCATION }}" checkout ${{ inputs.config-hash }}
-          else
-            git -C "${{ env.BASE_EXPERIMENT_LOCATION }}" checkout ${{ inputs.config-ref }}
-          fi
+          git -C "${{ env.BASE_EXPERIMENT_LOCATION }}" checkout ${{ inputs.config-hash }}
           cd "${{ env.BASE_EXPERIMENT_LOCATION }}"
 
           # Setup a compared checksum (if it exists)
@@ -221,12 +210,7 @@ jobs:
 
       - name: Generate Test Output Artifact Name
         id: artifact
-        run: |
-          if [ -n "${{ inputs.config-hash }}" ]; then
-            echo "name=${{ github.event.repository.name }}-${{ inputs.config-hash }}" >> $GITHUB_OUTPUT
-          else
-            echo "name=${{ github.event.repository.name }}-${{ inputs.config-ref }}" >> $GITHUB_OUTPUT
-          fi
+        run: echo "name=${{ github.event.repository.name }}-${{ inputs.config-hash }}" >> $GITHUB_OUTPUT
 
       - name: Upload Test Output
         id: upload


### PR DESCRIPTION
This PR:
 - Adds a new input to `test-repro.yml` - `config-hash`. This is so all experiment directories will be set as
 `${{ vars.EXPERIMENTS_LOCATION }}/${{ github.event.repository.name }}/${{ inputs.config-ref }}/${{ inputs.config-hash }}` where `config-ref` is the branch or tag name and `config-hash` is the SHA commit hash. This is to make it easier to group commits to a particular branch in a PR (when eventually we set up automation to delete them when PR is closed) and also keep checksums on intermediate commits
 - After the test results are checked for errors (depending on https://github.com/ACCESS-NRI/model-config-tests/pull/173- this should indicate if the model did not run correctly),  remove any directories apart from `checksum`.
 
Contributes to #175 - this PR currently does not remove anything when config PRs are closed.

TODO:
- Testing?
- Double check the checksums file exists in artefact before deleting. 
- Could there be a repo setting to prevent deletion of outputs?
- Make the `rm -rf` slightly safer?