### PR TITLE
Fix parsing job ID in payu run submission stdout

### DIFF
--- a/src/model_config_tests/exp_test_helper.py
+++ b/src/model_config_tests/exp_test_helper.py
@@ -345,10 +345,15 @@ def setup_exp(
 
 
 def parse_run_id(stdout: str) -> str:
-    """Parses the run ID from the subprocess stdout that submits payu run.
-    The run ID is the first line of the stdout."""
-    run_id = stdout.splitlines()[0]
-    return run_id
+    """Parses the Gadi PBS run ID from the subprocess stdout that submits payu
+    run"""
+    ids = parse_gadi_pbs_ids(stdout)
+    if len(ids) != 1:
+        raise RuntimeError(
+            "Expected 1 job ID in payu run submission, "
+            f"but found {len(ids)}. IDs: {ids}"
+        )
+    return ids[0]
 
 
 def parse_gadi_pbs_ids(stdout: str) -> list[str]:

--- a/tests/test_exp_test_helper.py
+++ b/tests/test_exp_test_helper.py
@@ -186,18 +186,29 @@ def test_experiment_submit_payu_run_error(mock_run, exp):
     assert exp.run_id is None
 
 
-TEST_RUN_STDOUT = """137650670.gadi-pbs
-Loading input manifest: manifests/input.yaml
-Loading restart manifest: manifests/restart.yaml
-Loading exe manifest: manifests/exe.yaml
-payu: Found modules in /opt/Modules/v4.3.0
-qsub -q express -- /path/to/env/bin/python /path/to/env/bin/payu-run
-"""
-
-
-def test_parse_run_id():
-    run_id = parse_run_id(TEST_RUN_STDOUT)
+@pytest.mark.parametrize(
+    "example_stdout",
+    [
+        "137650670.gadi-pbs\ngadi-pbs ID output is first line\n",
+        "gadi-pbs ID\nIs the last line\n137650670.gadi-pbs\n",
+    ],
+)
+def test_parse_run_id(example_stdout):
+    run_id = parse_run_id(example_stdout)
     assert run_id == "137650670.gadi-pbs"
+
+
+@pytest.mark.parametrize(
+    "example_stdout",
+    [
+        "No job ID here\nJust some output\n",
+        "Multiple IDs\n12345.gadi-pbs\n67890.gadi-pbs\n",
+    ],
+)
+def test_parse_run_id_parsing_error(example_stdout):
+    error_msg = "Expected 1 job ID in payu run submission.*"
+    with pytest.raises(RuntimeError, match=error_msg):
+        parse_run_id(example_stdout)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Payu in versions <= `1.1.7` prints the job ID as the first line of the payu run submission standard output, while in `payu/dev` it may be the last line. This PR re-uses a function that parses IDs from PBS stdout logs to parse only one ID from the printed output. 

Tested historical repro tests with an OM2 config with virtual environments built from the `payu/dev` module and the released `payu/1.1.7` module. Still running a full suite of repro tests an OM3 configuration for a sanity check 

Closes #185