### PR TITLE
Add repro payu setup check - this should pick up changes to manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Running all tests in the pytest suite on a configuration will likely fail as the
 - `repro_determinism_restart`: Determinism test that confirms repeated experiments with two consecutive runs give the same result.
 - `repro_restart`: Restart reproducibility test that confirms two short consecutive model runs give the same result as a longer single model run.
 - `repro_payu_setup`: Test payu setup reproducibility; fail if MD5 of any file in manifest is changed.
-- `manifests_unchanged`: Uses `git diff` to check for any unauthorized changes in manifest.
+- `manifests_unchanged`: Uses `git diff` to check manifests are up-to-date. If only fast hashes (e.g. `binhash`) are different, the manifests are reproducible, but `payu setup` may take longer to run as `md5` hashes need to be recalculated.  This test is not intended for tagged configurations.
 - `manifests`: A shortcut to run both `manifests_unchanged` and `repro_payu_setup`.
 - `slow`: Tests that are slow to run
 - `dev_config`: General configuration QA tests.

--- a/README.md
+++ b/README.md
@@ -90,9 +90,14 @@ Running all tests in the pytest suite on a configuration will likely fail as the
 - `repro_determinism`: Determinism test that confirms repeated model runs give the same result.
 - `repro_determinism_restart`: Determinism test that confirms repeated experiments with two consecutive runs give the same result.
 - `repro_restart`: Restart reproducibility test that confirms two short consecutive model runs give the same result as a longer single model run.
+- `repro_payu_setup`: Test payu setup reproducibility; fail if MD5 of any file in manifest is changed.
+- `manifests_unchanged`: Uses `git diff` to check for any unauthorized changes in manifest.
+- `manifests`: A shortcut to run both `manifests_unchanged` and `repro_payu_setup`.
 - `slow`: Tests that are slow to run
 - `dev_config`: General configuration QA tests.
 - `config`: Configuration QA tests for released branches. This includes the `dev_config` tests.
+
+
 
 There are also model-specific markers for configuration QA tests, e.g., `access_om2`, `access_esm1p5`, `access_om3` and `access_esm1p6`. For a list of all available markers,
 run:

--- a/src/model_config_tests/config_tests/conftest.py
+++ b/src/model_config_tests/config_tests/conftest.py
@@ -131,6 +131,10 @@ def pytest_configure(config):
         "markers",
         "repro_determinism_restart: mark tests that check determinism restart",
     )
+    config.addinivalue_line(
+        "markers",
+        "repro_payu_setup: mark tests that check payu setup reproducibility",
+    )
     config.addinivalue_line("markers", "slow: mark tests that are slow to run")
     config.addinivalue_line(
         "markers",

--- a/src/model_config_tests/config_tests/conftest.py
+++ b/src/model_config_tests/config_tests/conftest.py
@@ -135,6 +135,14 @@ def pytest_configure(config):
         "markers",
         "repro_payu_setup: mark tests that check payu setup reproducibility",
     )
+    config.addinivalue_line(
+        "markers",
+        "manifests: mark tests that check payu setup does not change manifests files or md5",
+    )
+    config.addinivalue_line(
+        "markers",
+        "manifests_unchanged: mark tests that check payu setup does not change manifests files",
+    )
     config.addinivalue_line("markers", "slow: mark tests that are slow to run")
     config.addinivalue_line(
         "markers",

--- a/src/model_config_tests/config_tests/test_bit_reproducibility.py
+++ b/src/model_config_tests/config_tests/test_bit_reproducibility.py
@@ -333,7 +333,7 @@ class TestBitReproducibility:
 @pytest.mark.repro
 @pytest.mark.manifests
 @pytest.mark.repro_payu_setup
-def test_payu_setup_repro_flag(control_path, output_path):
+def test_repro_payu_setup(control_path, output_path):
     """
     Test payu setup with `--repro` flag which errors if md5 of any files in payu manifests are changed.
     """

--- a/src/model_config_tests/config_tests/test_bit_reproducibility.py
+++ b/src/model_config_tests/config_tests/test_bit_reproducibility.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 import pytest
 
-from model_config_tests.exp_test_helper import Experiments, ExpTestHelper
+from model_config_tests.exp_test_helper import Experiments, ExpTestHelper, setup_exp
 from model_config_tests.util import DAY_IN_SECONDS, HOUR_IN_SECONDS
 
 # Names of shared experiments
@@ -328,3 +328,15 @@ class TestBitReproducibility:
         )
 
         assert produced == expected
+
+
+@pytest.mark.repro_payu_setup
+def test_repro_payu_setup(control_path, output_path):
+    """
+    Test payu setup with --reproduce which errors if payu manifests full hashes are changed
+    """
+    experiment = setup_exp(control_path, output_path, exp_name="repro_payu_setup")
+    try:
+        experiment.setup_reproduce()
+    except Exception as error:
+        pytest.fail(f"{error}")

--- a/src/model_config_tests/config_tests/test_bit_reproducibility.py
+++ b/src/model_config_tests/config_tests/test_bit_reproducibility.py
@@ -330,13 +330,30 @@ class TestBitReproducibility:
         assert produced == expected
 
 
+@pytest.mark.repro
+@pytest.mark.manifests
 @pytest.mark.repro_payu_setup
-def test_repro_payu_setup(control_path, output_path):
+def test_payu_setup_repro_flag(control_path, output_path):
     """
-    Test payu setup with `git diff` which errors if any files in payu manifests are changed.
+    Test payu setup with `--repro` flag which errors if md5 of any files in payu manifests are changed.
     """
     experiment = setup_exp(control_path, output_path, exp_name="repro_payu_setup")
     try:
         experiment.setup_reproduce()
+    except Exception as error:
+        pytest.fail(f"{error}")
+
+
+@pytest.mark.manifests
+@pytest.mark.manifests_unchanged
+def test_manifests_unchanged(control_path, output_path):
+    """
+    Test payu setup with `git diff` which errors if any files in payu manifests are changed.
+    """
+    experiment = setup_exp(
+        control_path, output_path, exp_name="setup_unchanged_manifests"
+    )
+    try:
+        experiment.setup_manifests_unchanged()
     except Exception as error:
         pytest.fail(f"{error}")

--- a/src/model_config_tests/config_tests/test_bit_reproducibility.py
+++ b/src/model_config_tests/config_tests/test_bit_reproducibility.py
@@ -333,7 +333,7 @@ class TestBitReproducibility:
 @pytest.mark.repro_payu_setup
 def test_repro_payu_setup(control_path, output_path):
     """
-    Test payu setup with --reproduce which errors if payu manifests full hashes are changed
+    Test payu setup with `git diff` which errors if any files in payu manifests are changed.
     """
     experiment = setup_exp(control_path, output_path, exp_name="repro_payu_setup")
     try:

--- a/src/model_config_tests/exp_test_helper.py
+++ b/src/model_config_tests/exp_test_helper.py
@@ -82,6 +82,34 @@ class ExpTestHelper:
         """
         return self.model.output_exists()
 
+    def setup_reproduce(self):
+        """
+        Run payu setup command with --reproduce flag
+        """
+        owd = Path.cwd()
+        # Change to experiment directory and run.
+        os.chdir(self.control_path)
+
+        try:
+            setup_command = [
+                "payu",
+                "setup",
+                "--lab",
+                str(self.lab_path),
+                "--reproduce",
+            ]
+            print(f"Running payu setup command: {setup_command}")
+            result = sp.run(setup_command, capture_output=True, text=True)
+        finally:
+            # Change back to original working directory
+            os.chdir(owd)
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to run payu setup with --reproduce. Error: {result.stderr}\n"
+                f"Full output: {result.stdout}"
+            )
+
     def setup_for_test_run(self):
         """
         Various config.yaml settings need to be modified in order to run in the

--- a/src/model_config_tests/exp_test_helper.py
+++ b/src/model_config_tests/exp_test_helper.py
@@ -110,9 +110,22 @@ class ExpTestHelper:
             os.chdir(owd)
 
         if result.stdout != "":
-            raise RuntimeError(
-                f"Manifests have been modified. The modified files include: {result.stdout}.\n"
-            )
+            # Collect and display the top 10 lines of the diff for each modified file
+            files = result.stdout.strip().split("\n")
+            error_message = ""
+            for file in files:
+                error_message += f"Modifications are detected in {file}:\n"
+                diff_details = sp.run(
+                    ["git", "diff", f"{file}"],
+                    capture_output=True,
+                    text=True,
+                )
+                diff_lines = diff_details.stdout.splitlines()
+                top_lines = "\n".join(diff_lines[2:12])
+                if len(diff_lines) > 12:
+                    top_lines += "\n... (truncated)"
+                error_message += f"Changes are: \n {top_lines}\n"
+            raise RuntimeError(f"{error_message}")
 
     def setup_for_test_run(self):
         """

--- a/src/model_config_tests/exp_test_helper.py
+++ b/src/model_config_tests/exp_test_helper.py
@@ -84,6 +84,34 @@ class ExpTestHelper:
 
     def setup_reproduce(self):
         """
+        Run payu setup with `--repro` flag to check if md5 hashes have changed in the manifests.
+        """
+        owd = Path.cwd()
+        # Change to experiment directory and run.
+        os.chdir(self.control_path)
+
+        try:
+            setup_command = [
+                "payu",
+                "setup",
+                "--lab",
+                str(self.lab_path),
+                "--reproduce",
+            ]
+            print(f"Running payu setup command: {setup_command}")
+            result = sp.run(setup_command, capture_output=True, text=True)
+        finally:
+            # Change back to original working directory
+            os.chdir(owd)
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to run payu setup with --reproduce. Error: {result.stderr}\n"
+                f"Full output: {result.stdout}"
+            )
+
+    def setup_manifests_unchanged(self):
+        """
         Run payu setup command and check if manifests files have been changed with `git diff`.
         """
         owd = Path.cwd()

--- a/src/model_config_tests/exp_test_helper.py
+++ b/src/model_config_tests/exp_test_helper.py
@@ -110,10 +110,27 @@ class ExpTestHelper:
         if result.returncode != 0:
             raise RuntimeError(
                 "Failed to run payu setup"
-                + (" with --reproduce" if reproduce else "")
+                + (" with --reproduce.\n" if reproduce else ".\n")
                 + f"{'='*10}STDOUT{'='*10}\n {result.stdout}\n"
                 f"{'='*10}STDERR{'='*10}\n {result.stderr}\n"
             )
+
+    def run_git_diff(self, path, extra_args=None):
+        """
+        Run git diff command on the given path and return the output.
+        """
+        command = ["git", "-C", str(path), "diff"] + extra_args if extra_args else []
+
+        result = sp.run(command, capture_output=True, text=True)
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Git command failed with exit code {result.returncode}.\n"
+                f"{'='*10}STDOUT{'='*10}\n {result.stdout}\n"
+                f"{'='*10}STDERR{'='*10}\n {result.stderr}\n"
+            )
+
+        return result.stdout
 
     def setup_reproduce(self):
         """
@@ -127,21 +144,12 @@ class ExpTestHelper:
         """
         self.setup(reproduce=False)
 
-        result = sp.run(
-            ["git", "diff", "--name-only", str(self.control_path / "manifests/")],
-            capture_output=True,
-            text=True,
+        result = self.run_git_diff(
+            self.control_path, extra_args=["--name-only", "manifests/"]
         )
-
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"Git command failed with exit code {result.returncode}.\n"
-                f"{'='*10}STDOUT{'='*10}\n {result.stdout}\n"
-                f"{'='*10}STDERR{'='*10}\n {result.stderr}\n"
-            )
-        elif result.stdout != "":
+        if result != "":
             # Collect and display the top 10 lines of the diff for each modified file
-            files = result.stdout.strip().split("\n")
+            files = result.strip().split("\n")
             error_message = "Modifications are detected in file:\n"
             error_message += "\n".join(" - " + file for file in files) + "\n"
             error_message += "\nIf md5 hashes have changed, this indicates file contents being different."
@@ -151,12 +159,10 @@ this will mean the configuration can reproduce the manifests
 but `payu setup` will take longer to run as it needs to re-calculate all the md5 hashes.
             """
             for file in files:
-                diff_details = sp.run(
-                    ["git", "-C", str(self.control_path), "diff", f"{file}"],
-                    capture_output=True,
-                    text=True,
+                diff_details = self.run_git_diff(
+                    self.control_path, extra_args=[f"{file}"]
                 )
-                diff_lines = diff_details.stdout.splitlines()
+                diff_lines = diff_details.splitlines()
                 top_lines = "\n".join(diff_lines[2:12])
                 if len(diff_lines) > 12:
                     top_lines += "\n... (truncated)"

--- a/src/model_config_tests/exp_test_helper.py
+++ b/src/model_config_tests/exp_test_helper.py
@@ -94,11 +94,15 @@ class ExpTestHelper:
             setup_command = ["payu", "setup", "--lab", str(self.lab_path)]
             print(f"Running payu setup command: {setup_command}")
             setup_result = sp.run(setup_command, capture_output=True, text=True)
-            if setup_result.returncode != 0 or "error" in setup_result.stderr.lower():
+            if setup_result.returncode != 0:
                 raise RuntimeError(
                     f"Error during payu setup. \n"
                     f"{'='*10}STDOUT{'='*10}\n {setup_result.stdout}\n"
                     f"{'='*10}STDERR{'='*10}\n {setup_result.stderr}\n"
+                )
+            elif "error" in setup_result.stderr.lower():
+                warnings.warn(
+                    f"Payu setup existed safely with errors in stderr:\n{setup_result.stderr}. Proceeding to modification check."
                 )
             result = sp.run(
                 ["git", "diff", "--name-only", "manifests/"],
@@ -112,11 +116,17 @@ class ExpTestHelper:
         if result.stdout != "":
             # Collect and display the top 10 lines of the diff for each modified file
             files = result.stdout.strip().split("\n")
-            error_message = ""
+            error_message = "Modifications are detected in file:\n"
+            error_message += "\n".join(" - " + file for file in files) + "\n"
+            error_message += "\nIf md5 hashes have changed, this indicates file contents being different."
+            error_message += """
+If binhashes/paths have changed but md5's are the same,
+this will mean the configuration can reproduce the manifests
+but `payu setup` will take longer to run as it needs to re-calculate all the md5 hashes.
+            """
             for file in files:
-                error_message += f"Modifications are detected in {file}:\n"
                 diff_details = sp.run(
-                    ["git", "diff", f"{file}"],
+                    ["git", "-C", str(self.control_path), "diff", f"{file}"],
                     capture_output=True,
                     text=True,
                 )
@@ -124,7 +134,7 @@ class ExpTestHelper:
                 top_lines = "\n".join(diff_lines[2:12])
                 if len(diff_lines) > 12:
                     top_lines += "\n... (truncated)"
-                error_message += f"Changes are: \n {top_lines}\n"
+                error_message += f"\n{'='*10} Diff for {file} {'='*10}\n{top_lines}\n"
             raise RuntimeError(f"{error_message}")
 
     def setup_for_test_run(self):

--- a/src/model_config_tests/exp_test_helper.py
+++ b/src/model_config_tests/exp_test_helper.py
@@ -82,9 +82,10 @@ class ExpTestHelper:
         """
         return self.model.output_exists()
 
-    def setup_reproduce(self):
+    def setup(self, reproduce=False):
         """
-        Run payu setup with `--repro` flag to check if md5 hashes have changed in the manifests.
+        Run payu setup command. If reproduce is True, run with --reproduce flag
+        to check if md5 hashes have changed in the manifests.
         """
         owd = Path.cwd()
         # Change to experiment directory and run.
@@ -96,49 +97,49 @@ class ExpTestHelper:
                 "setup",
                 "--lab",
                 str(self.lab_path),
-                "--reproduce",
             ]
+            if reproduce:
+                setup_command.append("--reproduce")
             print(f"Running payu setup command: {setup_command}")
             result = sp.run(setup_command, capture_output=True, text=True)
+
         finally:
             # Change back to original working directory
             os.chdir(owd)
 
         if result.returncode != 0:
             raise RuntimeError(
-                f"Failed to run payu setup with --reproduce. Error: {result.stderr}\n"
-                f"Full output: {result.stdout}"
+                "Failed to run payu setup"
+                + (" with --reproduce" if reproduce else "")
+                + f"{'='*10}STDOUT{'='*10}\n {result.stdout}\n"
+                f"{'='*10}STDERR{'='*10}\n {result.stderr}\n"
             )
+
+    def setup_reproduce(self):
+        """
+        Run payu setup with `--repro` flag to check if md5 hashes have changed in the manifests.
+        """
+        self.setup(reproduce=True)
 
     def setup_manifests_unchanged(self):
         """
         Run payu setup command and check if manifests files have been changed with `git diff`.
         """
-        owd = Path.cwd()
-        # Change to experiment directory and run.
-        os.chdir(self.control_path)
+        self.setup(reproduce=False)
 
-        try:
-            setup_command = ["payu", "setup", "--lab", str(self.lab_path)]
-            print(f"Running payu setup command: {setup_command}")
-            setup_result = sp.run(setup_command, capture_output=True, text=True)
-            if setup_result.returncode != 0:
-                raise RuntimeError(
-                    f"Error during payu setup. \n"
-                    f"{'='*10}STDOUT{'='*10}\n {setup_result.stdout}\n"
-                    f"{'='*10}STDERR{'='*10}\n {setup_result.stderr}\n"
-                )
+        result = sp.run(
+            ["git", "diff", "--name-only", str(self.control_path / "manifests/")],
+            capture_output=True,
+            text=True,
+        )
 
-            result = sp.run(
-                ["git", "diff", "--name-only", "manifests/"],
-                capture_output=True,
-                text=True,
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Git command failed with exit code {result.returncode}.\n"
+                f"{'='*10}STDOUT{'='*10}\n {result.stdout}\n"
+                f"{'='*10}STDERR{'='*10}\n {result.stderr}\n"
             )
-        finally:
-            # Change back to original working directory
-            os.chdir(owd)
-
-        if result.stdout != "":
+        elif result.stdout != "":
             # Collect and display the top 10 lines of the diff for each modified file
             files = result.stdout.strip().split("\n")
             error_message = "Modifications are detected in file:\n"

--- a/src/model_config_tests/exp_test_helper.py
+++ b/src/model_config_tests/exp_test_helper.py
@@ -128,10 +128,7 @@ class ExpTestHelper:
                     f"{'='*10}STDOUT{'='*10}\n {setup_result.stdout}\n"
                     f"{'='*10}STDERR{'='*10}\n {setup_result.stderr}\n"
                 )
-            elif "error" in setup_result.stderr.lower():
-                warnings.warn(
-                    f"Payu setup existed safely with errors in stderr:\n{setup_result.stderr}. Proceeding to modification check."
-                )
+
             result = sp.run(
                 ["git", "diff", "--name-only", "manifests/"],
                 capture_output=True,

--- a/src/model_config_tests/exp_test_helper.py
+++ b/src/model_config_tests/exp_test_helper.py
@@ -84,30 +84,34 @@ class ExpTestHelper:
 
     def setup_reproduce(self):
         """
-        Run payu setup command with --reproduce flag
+        Run payu setup command and check if manifests files have been changed with `git diff`.
         """
         owd = Path.cwd()
         # Change to experiment directory and run.
         os.chdir(self.control_path)
 
         try:
-            setup_command = [
-                "payu",
-                "setup",
-                "--lab",
-                str(self.lab_path),
-                "--reproduce",
-            ]
+            setup_command = ["payu", "setup", "--lab", str(self.lab_path)]
             print(f"Running payu setup command: {setup_command}")
-            result = sp.run(setup_command, capture_output=True, text=True)
+            setup_result = sp.run(setup_command, capture_output=True, text=True)
+            if setup_result.returncode != 0 or "error" in setup_result.stderr.lower():
+                raise RuntimeError(
+                    f"Error during payu setup. \n"
+                    f"{'='*10}STDOUT{'='*10}\n {setup_result.stdout}\n"
+                    f"{'='*10}STDERR{'='*10}\n {setup_result.stderr}\n"
+                )
+            result = sp.run(
+                ["git", "diff", "--name-only", "manifests/"],
+                capture_output=True,
+                text=True,
+            )
         finally:
             # Change back to original working directory
             os.chdir(owd)
 
-        if result.returncode != 0:
+        if result.stdout != "":
             raise RuntimeError(
-                f"Failed to run payu setup with --reproduce. Error: {result.stderr}\n"
-                f"Full output: {result.stdout}"
+                f"Manifests have been modified. The modified files include: {result.stdout}.\n"
             )
 
     def setup_for_test_run(self):

--- a/tests/test_exp_test_helper.py
+++ b/tests/test_exp_test_helper.py
@@ -568,17 +568,17 @@ def test_setup_reproduce_error(mock_run, exp):
     mock_result.stdout = "Check manifest"
     mock_run.return_value = mock_result
 
+    # Store original current working directory
+    owd = Path.cwd()
+
     with pytest.raises(RuntimeError) as excinfo:
         exp.setup_reproduce()
 
-        assert (
-            f"Failed to run payu setup with --reproduce. Error: {mock_result.stderr}"
-            in str(excinfo.value)
-        )
-        assert f"Full output: {mock_result.stdout}" in str(excinfo.value)
+    assert "Failed to run payu setup with --reproduce.\n" in str(excinfo.value)
+    assert f"{'='*10}STDOUT{'='*10}\n {mock_result.stdout}\n" in str(excinfo.value)
 
-        # assert returning to the original work directory
-        assert Path.cwd() == exp.control_path
+    # assert returning to the original work directory
+    assert Path.cwd() == owd
 
 
 @patch("subprocess.run")
@@ -610,14 +610,24 @@ def test_setup_manifests_unchanged_show_changes(mock_run, exp):
     # Mock the `payu setup` succeed first
     setup_success = MagicMock(returncode=0, stdout="Payu setup succeeded")
 
-    top_lines = "+new line\n-old line"
+    top_lines = """--- a/{diff_file}
++++ b/{diff_file}
++new line
+-old line
+    """
     diff_file = "manifests/input.yaml"
     # Then mock the `git diff --name-only` to show which files are changed
     git_diff_name_only = MagicMock(returncode=0, stdout=diff_file)
 
     # Mock the `git diff` to show the detailed changes in the file
     git_diff_run = MagicMock(
-        returncode=0, stdout=(f"--- a/{diff_file}\n+++ b/{diff_file}\n" + top_lines)
+        returncode=0,
+        stdout=(
+            f"""diff --git a/{diff_file} b/{diff_file}
+index abc123...zyx789 100111
+"""
+        )
+        + top_lines,
     )
 
     # Run these mocks in sequence

--- a/tests/test_exp_test_helper.py
+++ b/tests/test_exp_test_helper.py
@@ -591,14 +591,17 @@ def test_setup_manifests_unchanged_fail_setup(mock_run, exp):
     mock_result.stdout = "Payu setup output"
     mock_run.return_value = mock_result
 
+    # Store original current working directory
+    owd = Path.cwd()
+
     with pytest.raises(RuntimeError) as excinfo:
         exp.setup_manifests_unchanged()
 
-        assert "Error during payu setup." in str(excinfo.value)
-        assert f"{'='*10}STDOUT{'='*10}\n {mock_result.stdout}\n" in str(excinfo.value)
+    assert "Failed to run payu setup" in str(excinfo.value)
+    assert f"{'='*10}STDOUT{'='*10}\n {mock_result.stdout}\n" in str(excinfo.value)
 
-        # assert returning to the original work directory
-        assert Path.cwd() == exp.control_path
+    # assert returning to the original work directory
+    assert Path.cwd() == owd
 
 
 @patch("subprocess.run")
@@ -607,23 +610,29 @@ def test_setup_manifests_unchanged_show_changes(mock_run, exp):
     # Mock the `payu setup` succeed first
     setup_success = MagicMock(returncode=0, stdout="Payu setup succeeded")
 
+    top_lines = "+new line\n-old line"
+    diff_file = "manifests/input.yaml"
     # Then mock the `git diff --name-only` to show which files are changed
-    git_diff_name_only = MagicMock(returncode=1, stdout="manifests/input.yaml")
+    git_diff_name_only = MagicMock(returncode=0, stdout=diff_file)
 
     # Mock the `git diff` to show the detailed changes in the file
-    git_diff_output = (
-        "--- a/manifests/input.yaml\n+++ b/manifests/input.yaml\n+new line\n-old line"
+    git_diff_run = MagicMock(
+        returncode=0, stdout=(f"--- a/{diff_file}\n+++ b/{diff_file}\n" + top_lines)
     )
-    git_diff_run = MagicMock(returncode=0, stdout=git_diff_output)
 
     # Run these mocks in sequence
     mock_run.side_effect = [setup_success, git_diff_name_only, git_diff_run]
 
+    # Store original current working directory
+    owd = Path.cwd()
+
     with pytest.raises(RuntimeError) as excinfo:
         exp.setup_manifests_unchanged()
 
-        assert "Modifications are detected in file:\n" in str(excinfo.value)
-        assert git_diff_output in str(excinfo.value)
+    assert "Modifications are detected in file:\n" in str(excinfo.value)
+    assert f"\n{'='*10} Diff for {diff_file} {'='*10}\n{top_lines}\n" in str(
+        excinfo.value
+    )
 
-        # assert returning to the original work directory
-        assert Path.cwd() == exp.control_path
+    # assert returning to the original work directory
+    assert Path.cwd() == owd

--- a/tests/test_exp_test_helper.py
+++ b/tests/test_exp_test_helper.py
@@ -1,7 +1,7 @@
 import shutil
 import subprocess
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import yaml
@@ -556,3 +556,74 @@ def test_experiments_check_experiment_error(tmp_path):
     )
     with pytest.raises(RuntimeError, match=error_msg):
         exps.check_experiment("error_exp")
+
+
+@patch("subprocess.run")
+def test_setup_reproduce_error(mock_run, exp):
+    """Test that payu setup --repro fails raises an error and return to original work directory"""
+    # Mock the payu setup --repro to fail
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stderr = "MD5 mismatch"
+    mock_result.stdout = "Check manifest"
+    mock_run.return_value = mock_result
+
+    with pytest.raises(RuntimeError) as excinfo:
+        exp.setup_reproduce()
+
+        assert (
+            f"Failed to run payu setup with --reproduce. Error: {mock_result.stderr}"
+            in str(excinfo.value)
+        )
+        assert f"Full output: {mock_result.stdout}" in str(excinfo.value)
+
+        # assert returning to the original work directory
+        assert Path.cwd() == exp.control_path
+
+
+@patch("subprocess.run")
+def test_setup_manifests_unchanged_fail_setup(mock_run, exp):
+    """Test that an error is raised when payu setup fails in setup_manifests_unchanged()"""
+    # Mock the payu setup --repro to fail with unchanged manifests
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stderr = "Setup failed"
+    mock_result.stdout = "Payu setup output"
+    mock_run.return_value = mock_result
+
+    with pytest.raises(RuntimeError) as excinfo:
+        exp.setup_manifests_unchanged()
+
+        assert "Error during payu setup." in str(excinfo.value)
+        assert f"{'='*10}STDOUT{'='*10}\n {mock_result.stdout}\n" in str(excinfo.value)
+
+        # assert returning to the original work directory
+        assert Path.cwd() == exp.control_path
+
+
+@patch("subprocess.run")
+def test_setup_manifests_unchanged_show_changes(mock_run, exp):
+    """Test that when manifests are changed, the `git diff` results are printed to stdout"""
+    # Mock the `payu setup` succeed first
+    setup_success = MagicMock(returncode=0, stdout="Payu setup succeeded")
+
+    # Then mock the `git diff --name-only` to show which files are changed
+    git_diff_name_only = MagicMock(returncode=1, stdout="manifests/input.yaml")
+
+    # Mock the `git diff` to show the detailed changes in the file
+    git_diff_output = (
+        "--- a/manifests/input.yaml\n+++ b/manifests/input.yaml\n+new line\n-old line"
+    )
+    git_diff_run = MagicMock(returncode=0, stdout=git_diff_output)
+
+    # Run these mocks in sequence
+    mock_run.side_effect = [setup_success, git_diff_name_only, git_diff_run]
+
+    with pytest.raises(RuntimeError) as excinfo:
+        exp.setup_manifests_unchanged()
+
+        assert "Modifications are detected in file:\n" in str(excinfo.value)
+        assert git_diff_output in str(excinfo.value)
+
+        # assert returning to the original work directory
+        assert Path.cwd() == exp.control_path


### PR DESCRIPTION
This PR adds a "repro_payu_setup" test marker, which selects a test that runs "payu setup" with  "--reproduce" flag - This is equivalent to setting the following in `config.yaml`:
```yaml
manifests:
  reproduce:
    inputs: true
    exe: true
    restart: true
```
So setup will raise an error if any full hashes in the generated manifests do not match.

Tested this with running `model-config-tests -m repro_payu_setup` on a configuration with unchanged manifests, and with a changed restart manifest (removed values from a binhash and md5), the error is:

```
E           Failed: Failed to run payu setup with --reproduce. Error: Loading access-esm1p6/2025.11.002
E             Loading requirement: cice5/access-esm1.6-2025.11.001-6umbsy5 mom5/2025.05.000-tzlv4hw um7/2025.11.000-nwpmrxg
E           Run cannot reproduce: manifest manifests/restart.yaml is not correct
E
E           Full output: laboratory path:  /scratch/tm70/jb4202/tmp/test-model-repro/lab
E           binary path:  /scratch/tm70/jb4202/tmp/test-model-repro/lab/bin
E           input path:  /scratch/tm70/jb4202/tmp/test-model-repro/lab/input
E           work path:  /scratch/tm70/jb4202/tmp/test-model-repro/lab/work
E           archive path:  /scratch/tm70/jb4202/tmp/test-model-repro/lab/archive
E           Experiment name is configured in config.yaml:  dev-preindustrial+concentrations-repro_payu_setup
E           payu: Found modules in /opt/Modules/v4.3.0
E           Loading input manifest: manifests/input.yaml
E           Loading restart manifest: manifests/restart.yaml
E           Loading exe manifest: manifests/exe.yaml
E           Setting up atmosphere
E           Setting up ocean
E           Setting up ice
E           Setting up coupler
E           Checking exe, input and restart manifests
E           Manifest path: stored hash != calculated hash
E             work/atmosphere/restart_dump.astart: md5: f65a5a631c516907330e7f2d4479d5e != f65a5a631c516907330e7f2d4479d5e2
```

An issue is that Payu raises an error when restart manifests are empty, e.g. ACCESS-OM2: 
```
 Failed: Failed to run payu setup with --reproduce. Error: Restart manifest must exist and be populated if reproduce is configured to True
```
I wonder if payu could not error here and only error if there was no pre-existing manifest and a new restart manifest was generated? 

Related to #9 