### PR TITLE
ACCESS-OM2 qa: Make mppnccombine-fast regex pattern less restrictive in `test_mppncombine_fast_collate_exe`

### DIFF
--- a/src/model_config_tests/config_tests/qa/test_access_om2_config.py
+++ b/src/model_config_tests/config_tests/qa/test_access_om2_config.py
@@ -116,7 +116,7 @@ class TestAccessOM2:
 
     def test_mppncombine_fast_collate_exe(self, config, branch):
         if branch.is_high_resolution:
-            pattern = r"/g/data/vk83/apps/mppnccombine-fast/.*/bin/mppnccombine-fast"
+            pattern = r".*mppnccombine-fast"
             if "collate" in config:
                 assert re.match(
                     pattern, config["collate"]["exe"]


### PR DESCRIPTION
This PR makes the regex pattern used to determine whether `mppnccombine-fast` is being used in high-res ACCESS-OM2 configs less restrictive.

Closes #192 