### PR TITLE
test-repro.yml: Fix PAYU_PBSNODE_CACHE env variable

### DIFF
--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -110,8 +110,8 @@ jobs:
           BASE_EXPERIMENT_LOCATION: ${{ env.EXPERIMENT_LOCATION }}/base-experiment
           COMPARED_CHECKSUM_LOCATION: ${{ env.EXPERIMENT_LOCATION }}/compared
           TEST_VENV_LOCATION: ${{ env.EXPERIMENT_LOCATION }}/test-venv
-          # Using vars.Experiment_location here to share pbsnodes.json among all repro CI tests
-          PAYU_PBSNODES_CACHE: ${{ vars.EXPERIMENT_LOCATION }}/.cache/pbs/pbsnodes.json
+          # Using vars.EXPERIMENTS_LOCATION here to share pbsnodes.json among all repro CI tests
+          PAYU_PBSNODES_CACHE: ${{ vars.EXPERIMENTS_LOCATION }}/.cache/pbs/pbsnodes.json
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash<<'EOT'
 


### PR DESCRIPTION
Fix the environment name in test-repro.yml - see error in https://github.com/payu-org/payu/issues/699

Related to #196