### PR TITLE
Repro Testing: Replace `/` with `-` in Uploaded Artifact

### DIFF
--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -223,7 +223,11 @@ jobs:
 
       - name: Generate Test Output Artifact Name
         id: artifact
-        run: echo "name=${{ github.event.repository.name }}-${{ inputs.run-context }}-${{ inputs.config-ref }}-${{ inputs.config-hash }}" >> $GITHUB_OUTPUT
+        # Sanitize the artifact name to remove the '/' in config-ref for automated auto/*/* configs PRs.
+        run: |
+          artifact_name="${{ github.event.repository.name }}-${{ inputs.run-context }}-${{ inputs.config-ref }}-${{ inputs.config-hash }}"
+          artifact_name_sanitized=$(tr '/' '-' <<< "${artifact_name}")
+          echo "name=${artifact_name_sanitized}" >> $GITHUB_OUTPUT
 
       - name: Upload Test Output
         id: upload


### PR DESCRIPTION
## Background

After #176, the `inputs.config-ref` was given to the artifact name to demarcate it a bit more. However, in the case of automated PRs created via the `!update-configs` command, the branch name contained slashes of the form `auto/prX/CONFIG`. Artifacts cannot contain `/`, so we need to sanitize our inputs in that case. 


## The PR

* Replace `/` with `-` in uploaded artifact name


## Testing

Locally on erroring artifact name:

```sh
tr '/' '-' <<< "access-om3-configs-pr1199-auto/pr207/dev-MC_100km_jra_ryf+wombatlite-495358423c148997284a4ca48c667dca9173c7e1"
# access-om3-configs-pr1199-auto-pr207-dev-MC_100km_jra_ryf+wombatlite-495358423c148997284a4ca48c667dca9173c7e1
```
