### PR TITLE
ACCESS-OM2 QA checks: Only expect ACCESS-OM2-BGC for old BGC configs

### DIFF
--- a/src/model_config_tests/config_tests/qa/test_access_om2_config.py
+++ b/src/model_config_tests/config_tests/qa/test_access_om2_config.py
@@ -66,10 +66,13 @@ class AccessOM2Branch:
         self.set_resolution()
 
         self.is_high_resolution = self.resolution in ["025deg", "01deg"]
-        self.is_bgc = any(m in branch_name for m in ["bgc", "wombat"])
+        is_bgc_old = "bgc" in branch_name
+        is_bgc_new = "wombat" in branch_name
+        self.is_bgc = is_bgc_old or is_bgc_new
 
         # Set expected module and model repository names
-        if self.is_bgc:
+        if is_bgc_old:
+            # Pre-generic-tracers BGC uses a separate exe
             self.module_name = ACCESS_OM2_BGC_MODULE_NAME
             self.model_repository_name = ACCESS_OM2_BGC_REPOSITORY_NAME
         else:


### PR DESCRIPTION
Sorry @jo-basevi, I rushed this the first time and missed the module and repo name checks:

The behaviour should be:
- if "bgc" is in the config name: use `ACCESS-OM2-BGC` (now-deprecated)
- if "wombat" is in the config name: use `ACCESS-OM2`