### PR TITLE
Create an issue when repro-ci result is error & assign target branch in test-repro

### DIFF
--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -79,20 +79,19 @@ jobs:
       - name: Setup Issue Variables
         id: variables
         run: |
-          if [[ "${{ needs.repro-ci.outputs.result }}" == "error" ]]; then
-            echo "status_msg=an error" >> $GITHUB_OUTPUT
-            echo "log_label=Error Run Log" >> $GITHUB_OUTPUT
-            echo "icon=:warning:" >> $GITHUB_OUTPUT
-            echo "title_word=Errored" >> $GITHUB_OUTPUT
-            echo "gh_label=type:repro-error" >> $GITHUB_OUTPUT
-            echo "gh_label_desc=Repro check error" >> $GITHUB_OUTPUT
-          else
+          if [[ "${{ needs.repro-ci.outputs.result }}" == "fail" ]]; then
             echo "status_msg=a failure" >> $GITHUB_OUTPUT
-            echo "log_label=Failed Run Log" >> $GITHUB_OUTPUT
             echo "icon=:x:" >> $GITHUB_OUTPUT
             echo "title_word=Failed" >> $GITHUB_OUTPUT
             echo "gh_label=type:repro-fail" >> $GITHUB_OUTPUT
             echo "gh_label_desc=Repro check failure" >> $GITHUB_OUTPUT
+          else
+            echo "status_msg=an error" >> $GITHUB_OUTPUT
+            echo "icon=:warning:" >> $GITHUB_OUTPUT
+            echo "title_word=Errored" >> $GITHUB_OUTPUT
+            echo "gh_label=type:repro-error" >> $GITHUB_OUTPUT
+            echo "gh_label_desc=Repro check error" >> $GITHUB_OUTPUT
+            
           fi
           config=${{ github.event.repository.name }}
           echo "config=$config" >> $GITHUB_OUTPUT
@@ -111,15 +110,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           BODY: |
-            Test summary:
-              ${{ steps.variables.outputs.icon }} ${{ needs.repro-ci.outputs.summary}}
+            <details>
+            <summary> Test summary </summary>
+              ${{ needs.repro-ci.outputs.summary}}
+            </details>
 
             <summary> Further information</summary>
-            There was ${{ steps.variables.outputs.status_msg }} of the scheduled reproducibility check on \`${{ github.repository }}\`.
+            There was ${{ steps.variables.outputs.status_msg }} of the scheduled check on \`${{ github.repository }}\`.
             Model: `${{ steps.variables.outputs.model }}`, found here: ${{ steps.variables.outputs.model-url }}
             Config Repo: `${{ steps.variables.outputs.config }}`, found here: ${{ steps.variables.outputs.config-url }}
-            Config Ref Tested for Reproducibility: `${{ inputs.config-ref }}`, found here: ${{ steps.variables.outputs.ref-url }}
-            ${{ steps.variables.outputs.log_label }}: ${{ steps.variables.outputs.run-url }}
+            Config Ref Tested: `${{ inputs.config-ref }}`, found here: ${{ steps.variables.outputs.ref-url }}
+            Github Run Log: ${{ steps.variables.outputs.run-url }}
             Experiment Location (Gadi): `${{ needs.repro-ci.outputs.experiment-location }}`
             Checksums created: In the `testing/checksum` directory of ${{ needs.repro-ci.outputs.artifact-url }}
             Checksums compared against: ${{ steps.variables.outputs.ref-url }}/testing/checksum
@@ -131,6 +132,6 @@ jobs:
           gh label create 'priority:blocker' --color B60205 || true
 
           gh issue create \
-            --title 'Scheduled Repro Check ${{ steps.variables.outputs.title_word }} for Config `${{ inputs.config-ref }}`' \
+            --title 'Scheduled Check ${{ steps.variables.outputs.title_word }} for Config `${{ inputs.config-ref }}`' \
             --label "${{ steps.variables.outputs.gh_label }},priority:blocker" \
             --body '${{ env.BODY }}'

--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -110,13 +110,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           BODY: |
-            <details>
-            <summary> Test summary </summary>
-              ${{ needs.repro-ci.outputs.summary}}
-            </details>
-
-            <summary> Further information</summary>
-            There was ${{ steps.variables.outputs.status_msg }} of the scheduled check on \`${{ github.repository }}\`.
+            Further information:
+            There was ${{ steps.variables.outputs.status_msg }} of the scheduled check on `${{ github.repository }}`.
             Model: `${{ steps.variables.outputs.model }}`, found here: ${{ steps.variables.outputs.model-url }}
             Config Repo: `${{ steps.variables.outputs.config }}`, found here: ${{ steps.variables.outputs.config-url }}
             Config Ref Tested: `${{ inputs.config-ref }}`, found here: ${{ steps.variables.outputs.ref-url }}
@@ -126,6 +121,12 @@ jobs:
             Checksums compared against: ${{ steps.variables.outputs.ref-url }}/testing/checksum
 
             Tagging @ACCESS-NRI/model-release
+
+            <details>
+            <summary> Test summary </summary>
+              ${{ needs.repro-ci.outputs.summary}}
+            </details>
+
         run: |
           # Create tags for the issue if they don't already exist
           gh label create '${{ steps.variables.outputs.gh_label }}' --description '${{ steps.variables.outputs.gh_label_desc }}' --color 000000 || true

--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -67,11 +67,11 @@ jobs:
       checks: write
 
   failed-repro:
-    name: Failed Reproduction Notifier
+    name: Failed Or Error Reproduction Notifier
     needs:
       - repro-ci
       - config
-    if: failure() || needs.repro-ci.outputs.result == 'fail'
+    if: failure() || needs.repro-ci.outputs.result == 'fail' || needs.repro-ci.outputs.result == 'error'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -79,6 +79,21 @@ jobs:
       - name: Setup Issue Variables
         id: variables
         run: |
+          if [[ "${{ needs.repro-ci.outputs.result }}" == "error" ]]; then
+            echo "status_msg=an error" >> $GITHUB_OUTPUT
+            echo "log_label=Error Run Log" >> $GITHUB_OUTPUT
+            echo "icon=:warning:" >> $GITHUB_OUTPUT
+            echo "title_word=Errored" >> $GITHUB_OUTPUT
+            echo "gh_label=type:repro-error" >> $GITHUB_OUTPUT
+            echo "gh_label_desc=Repro check error" >> $GITHUB_OUTPUT
+          else
+            echo "status_msg=a failure" >> $GITHUB_OUTPUT
+            echo "log_label=Failed Run Log" >> $GITHUB_OUTPUT
+            echo "icon=:x:" >> $GITHUB_OUTPUT
+            echo "title_word=Failed" >> $GITHUB_OUTPUT
+            echo "gh_label=type:repro-fail" >> $GITHUB_OUTPUT
+            echo "gh_label_desc=Repro check failure" >> $GITHUB_OUTPUT
+          fi
           config=${{ github.event.repository.name }}
           echo "config=$config" >> $GITHUB_OUTPUT
           echo "config-url=https://github.com/ACCESS-NRI/$config" >> $GITHUB_OUTPUT
@@ -96,12 +111,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           BODY: |
-            There was a failure of the scheduled reproducibility check on `${{ github.repository }}`.
+            Test summary:
+              ${{ steps.variables.outputs.icon }} ${{ needs.repro-ci.outputs.summary}}
 
+            <summary> Further information</summary>
+            There was ${{ steps.variables.outputs.status_msg }} of the scheduled reproducibility check on \`${{ github.repository }}\`.
             Model: `${{ steps.variables.outputs.model }}`, found here: ${{ steps.variables.outputs.model-url }}
             Config Repo: `${{ steps.variables.outputs.config }}`, found here: ${{ steps.variables.outputs.config-url }}
             Config Ref Tested for Reproducibility: `${{ inputs.config-ref }}`, found here: ${{ steps.variables.outputs.ref-url }}
-            Failed Run Log: ${{ steps.variables.outputs.run-url }}
+            ${{ steps.variables.outputs.log_label }}: ${{ steps.variables.outputs.run-url }}
             Experiment Location (Gadi): `${{ needs.repro-ci.outputs.experiment-location }}`
             Checksums created: In the `testing/checksum` directory of ${{ needs.repro-ci.outputs.artifact-url }}
             Checksums compared against: ${{ steps.variables.outputs.ref-url }}/testing/checksum
@@ -109,10 +127,10 @@ jobs:
             Tagging @ACCESS-NRI/model-release
         run: |
           # Create tags for the issue if they don't already exist
-          gh label create 'type:repro-fail' --description 'Repro check failure' --color 000000 || true
+          gh label create '${{ steps.variables.outputs.gh_label }}' --description '${{ steps.variables.outputs.gh_label_desc }}' --color 000000 || true
           gh label create 'priority:blocker' --color B60205 || true
 
           gh issue create \
-            --title 'Scheduled Repro Check Failed for Config `${{ inputs.config-ref }}`' \
-            --label "type:repro-fail,priority:blocker" \
+            --title 'Scheduled Repro Check ${{ steps.variables.outputs.title_word }} for Config `${{ inputs.config-ref }}`' \
+            --label "${{ steps.variables.outputs.gh_label }},priority:blocker" \
             --body '${{ env.BODY }}'

--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -110,7 +110,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           BODY: |
-            Further information:
             There was ${{ steps.variables.outputs.status_msg }} of the scheduled check on `${{ github.repository }}`.
             Model: `${{ steps.variables.outputs.model }}`, found here: ${{ steps.variables.outputs.model-url }}
             Config Repo: `${{ steps.variables.outputs.config }}`, found here: ${{ steps.variables.outputs.config-url }}

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -188,6 +188,7 @@ jobs:
           # Run model-config-tests pytests - this also generates checksums files.
           # If there is a checksum to compare against, add --checksum-path arg.
           model-config-tests -s -m "${{ inputs.test-markers }}" \
+            --target-branch "${{ inputs.compared-config-ref }}" \
             --output-path "${{ env.EXPERIMENT_LOCATION }}" \
             ${{ inputs.compared-config-ref != '' && '--checksum-path $COMPARED_CHECKSUM_FILE \' || '\' }}
             --junitxml="${{ env.EXPERIMENT_LOCATION }}/checksum/test_report.xml"


### PR DESCRIPTION
Major fix:
Previously, automated issues were only created when the repro-ci result was labeled as `failure`. This PR updates the logic to also trigger issue creation when the result is `error`.

Minor fix: 
Updated test-repro to explicitly assign the correct target branch when triggered via a GitHub comment. This is to avoid fallback to the `main` branch.