### PR TITLE
schedule workflow: Extend github run log url with attempt number

### DIFF
--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -101,7 +101,7 @@ jobs:
           echo "model=$model" >> $GITHUB_OUTPUT
           echo "model-url=https://github.com/ACCESS-NRI/$model" >> $GITHUB_OUTPUT
           echo "ref-url=${{ github.server_url }}/${{ github.repository }}/tree/${{ needs.config.outputs.config-hash }}" >> $GITHUB_OUTPUT
-          echo "run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
+          echo "run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}" >> $GITHUB_OUTPUT
 
           cat $GITHUB_OUTPUT
 


### PR DESCRIPTION
This PR just adds workflow run attempt number to the `Github Run Log` URL in the Issue text. 

Example URLs:
Workflow with multiple attempts:
https://github.com/ACCESS-NRI/access-om3-configs/actions/runs/24630470764/attempts/2

Workflow with one attempt:
https://github.com/ACCESS-NRI/access-om3-configs/actions/runs/19611547103/attempts/1

`github.run_attempt` is listed as a context value here: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context


Closes #209 

