### PR TITLE
Add sync:base_path check in QA test.

### DIFF
--- a/src/model_config_tests/config_tests/qa/test_config.py
+++ b/src/model_config_tests/config_tests/qa/test_config.py
@@ -233,11 +233,10 @@ class TestConfig:
             ), "Sync path to remote archive should not be set"
 
     def test_sync_path_is_none(self, config):
-        if "sync" in config:
-            if "path" in config["sync"]:
-                assert (
-                    config["sync"]["path"] is None
-                ), "Sync paths should be None if it is set"
+        if "sync" in config and "path" in config["sync"]:
+            assert (
+                config["sync"]["path"] is None
+            ), "Sync paths should be None if it is set"
 
     def test_experiment_name_is_not_defined(self, config):
         assert "experiment" not in config, (

--- a/src/model_config_tests/config_tests/qa/test_config.py
+++ b/src/model_config_tests/config_tests/qa/test_config.py
@@ -225,11 +225,19 @@ class TestConfig:
                 "enable"
             ], "Sync to remote archive should not be enabled"
 
-    def test_sync_path_is_not_set(self, config):
+    def test_sync_base_path_is_not_set(self, config):
         if "sync" in config:
             assert not (
-                "path" in config["sync"] and config["sync"]["path"] is not None
+                "base_path" in config["sync"]
+                and config["sync"]["base_path"] is not None
             ), "Sync path to remote archive should not be set"
+
+    def test_sync_path_is_none(self, config):
+        if "sync" in config:
+            if "path" in config["sync"]:
+                assert (
+                    config["sync"]["path"] is None
+                ), "Sync paths should be None if it is set"
 
     def test_experiment_name_is_not_defined(self, config):
         assert "experiment" not in config, (


### PR DESCRIPTION
This PR updates the QA test to check `base_path` is not set in sync in config.yaml, instead of checking `path`.

Closes #213.