### PR TITLE
Update QA test to not allow sync.path.

### DIFF
--- a/src/model_config_tests/config_tests/qa/test_config.py
+++ b/src/model_config_tests/config_tests/qa/test_config.py
@@ -230,13 +230,13 @@ class TestConfig:
             assert not (
                 "base_path" in config["sync"]
                 and config["sync"]["base_path"] is not None
-            ), "Sync path to remote archive should not be set"
+            ), "Sync base path to remote archive should not be configured"
 
-    def test_sync_path_is_none(self, config):
-        if "sync" in config and "path" in config["sync"]:
+    def test_sync_path_not_exists(self, config):
+        if "sync" in config:
             assert (
-                config["sync"]["path"] is None
-            ), "Sync paths should be None if it is set"
+                "path" not in config["sync"]
+            ), "Sync path should not exist since base_path is preferred"
 
     def test_experiment_name_is_not_defined(self, config):
         assert "experiment" not in config, (

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,11 +6,11 @@ HERE = os.path.dirname(__file__)
 RESOURCES_DIR = Path(f"{HERE}/resources")
 
 CLONE_CONFIGS = {
-    # ACCESS-OM2, branch: release-1deg_jra55_ryf
+    # ACCESS-OM2, branch: dev-1deg_jra55_ryf
     "om2-1deg": {
         "repo_url": "https://github.com/ACCESS-NRI/access-om2-configs.git",
-        "branch": "release-1deg_jra55_ryf",
-        "commit": "3537bca",
+        "branch": "dev-1deg_jra55_ryf",
+        "commit": "261f3ea",
     },
     # ACCESS-OM2, branch: dev-025deg_jra55_iaf_bgc
     "om2-025deg": {

--- a/tests/common.py
+++ b/tests/common.py
@@ -45,7 +45,7 @@ CLONE_CONFIGS = {
     # ACCESS-ESM1.6, branch: dev-preindustrial+concentrations
     "esm1p6-prein": {
         "repo_url": "https://github.com/ACCESS-NRI/access-esm1.6-configs.git",
-        "branch": "dev-preindustrial+concentrations",
+        "branch": "dev-piControl",
         "commit": "946134f",
     },
 }

--- a/tests/config_tests/qa/test_test_config.py
+++ b/tests/config_tests/qa/test_test_config.py
@@ -7,6 +7,7 @@ import pytest
 
 # Disable specific warnings from test_config tests
 warnings.filterwarnings("ignore", category=pytest.PytestUnknownMarkWarning)
+from model_config_tests.config_tests.qa.test_config import TestConfig as ConfigValidator
 from model_config_tests.config_tests.qa.test_config import get_spack_location_file
 
 
@@ -83,3 +84,62 @@ def test_get_spack_location_file_no_spack_location():
         error_msg = r"Failed to download a spack\.location .*"
         with pytest.raises(AssertionError, match=error_msg):
             get_spack_location_file("fake-repo", "fake-version")
+
+
+@pytest.fixture
+def checker():
+    return ConfigValidator()
+
+
+def test_test_sync_and_base_path(checker):
+    """Test that the test checks sync and base_path configurations."""
+    config_pass = {
+        "sync": {
+            "enable": False,
+            "base_path": None,
+        }
+    }
+    checker.test_sync_is_not_enabled(config_pass)
+    checker.test_sync_base_path_is_not_set(config_pass)
+
+    config_fail = {
+        "sync": {
+            "enable": True,
+            "base_path": "/base_path/to/sync",
+        }
+    }
+    with pytest.raises(
+        AssertionError, match="Sync to remote archive should not be enabled"
+    ):
+        checker.test_sync_is_not_enabled(config_fail)
+
+    with pytest.raises(
+        AssertionError,
+        match="Sync base path to remote archive should not be configured",
+    ):
+        checker.test_sync_base_path_is_not_set(config_fail)
+
+
+def test_test_sync_path_not_exists(checker):
+    """Test that the test properly checks sync path is not set."""
+    config_fail = {
+        "sync": {
+            "enable": False,
+            "path": "/path/to/sync",
+        }
+    }
+    with pytest.raises(
+        AssertionError, match="Sync path should not exist since base_path is preferred"
+    ):
+        checker.test_sync_path_not_exists(config_fail)
+
+    config_fail2 = {
+        "sync": {
+            "enable": False,
+            "path": None,
+        }
+    }
+    with pytest.raises(
+        AssertionError, match="Sync path should not exist since base_path is preferred"
+    ):
+        checker.test_sync_path_not_exists(config_fail2)


### PR DESCRIPTION
This PR updates the QA test to check `sync.path` not exits in the `config.yaml`.

Ref: [comment](https://github.com/ACCESS-NRI/model-config-tests/pull/214#discussion_r3199408191) in PR #214 