### PR TITLE
CI: Update Actions To Use Node 24

### DIFF
--- a/.github/actions/parse-ci-config/README.md
+++ b/.github/actions/parse-ci-config/README.md
@@ -25,10 +25,10 @@ This action parses the CI testing configuration file. The caller of the action n
 # ---------
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
-      
+
       - name: Read scheduled test config
         id: scheduled-config
         uses: access-nri/model-config-tests/.github/actions/parse-ci-config@main

--- a/.github/actions/parse-ci-config/action.yml
+++ b/.github/actions/parse-ci-config/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - name: Set up Python
       id: cp311
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
         update-environment: false

--- a/.github/actions/parse-junit-xml/action.yml
+++ b/.github/actions/parse-junit-xml/action.yml
@@ -13,7 +13,7 @@ runs:
   steps:
     - name: Set up Python
       id: cp311
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
         update-environment: false
@@ -27,7 +27,7 @@ runs:
           --filepath ${{ inputs.filepath }} \
           --output-filepath tmp-result.txt
 
-        # Save multiline file output to a summary 
+        # Save multiline file output to a summary
         echo 'summary<<EOF' >> $GITHUB_OUTPUT
         cat tmp-result.txt >> $GITHUB_OUTPUT
         echo 'EOF' >> $GITHUB_OUTPUT

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd #v3.0.1
 
   pypi-build:
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
           cache: 'pip'
@@ -57,7 +57,7 @@ jobs:
           path: dist
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
 
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd #v3.0.1
 
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python 3.11
         uses: actions/setup-python@v5
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/config-comment-test.yml
+++ b/.github/workflows/config-comment-test.yml
@@ -47,7 +47,7 @@ jobs:
       model-config-tests-version: ${{ steps.repro-config.outputs.model-config-tests-version }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
@@ -103,7 +103,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -281,7 +281,7 @@ jobs:
       ARTIFACT_LOCAL_LOCATION: /opt/artifact
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_COMMIT_CHECK_TOKEN }}

--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -172,7 +172,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ needs.config.outputs.qa-python-version }}
           # We can use cache:pip to cache model-config-tests despite the actual

--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -44,7 +44,7 @@ jobs:
     outputs:
       authorship: ${{ steps.head-commit.outputs.authorship }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 
@@ -67,7 +67,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 
@@ -107,7 +107,7 @@ jobs:
       - name: Checkout main
         # We fetch the repository history because in `steps.compared` we
         # attempt to get the last config tag.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -159,12 +159,12 @@ jobs:
       checks: write
     steps:
       - name: Checkout PR ${{ github.event.pull_request.number }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout model-config-tests requirements
         # This step checks out model-config-tests/pyproject.toml because it is
         # used as a cache key for model-config-tests in the next step
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: access-nri/model-config-tests
           path: model-config-tests
@@ -247,13 +247,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR Target
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.base_ref }}
           path: target
 
       - name: Checkout PR Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           path: source

--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -203,7 +203,7 @@ jobs:
 
       - name: Parse Test Report
         id: tests
-        uses: EnricoMi/publish-unit-test-result-action/composite@e780361cd1fc1b1a170624547b3ffda64787d365  #v2.12.0
+        uses: EnricoMi/publish-unit-test-result-action/linux@c950f6fb443cb5af20a377fd0dfaa78838901040  #v2.23.0
         with:
           files: ./test_report.xml
           comment_mode: off

--- a/.github/workflows/config-pr-2-confirm.yml
+++ b/.github/workflows/config-pr-2-confirm.yml
@@ -34,7 +34,7 @@ jobs:
           reaction: rocket
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_COMMIT_CHECK_TOKEN }}
@@ -106,7 +106,7 @@ jobs:
       ARTIFACT_LOCAL_LOCATION: /opt/artifact
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_COMMIT_CHECK_TOKEN }}

--- a/.github/workflows/config-pr-3-bump-tag.yml
+++ b/.github/workflows/config-pr-3-bump-tag.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-tags: true
 

--- a/.github/workflows/config-schedule-1-ci.yml
+++ b/.github/workflows/config-schedule-1-ci.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       refs: ${{ steps.get-scheduled-tests.outputs.refs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
 

--- a/.github/workflows/config-schedule-2-start.yml
+++ b/.github/workflows/config-schedule-2-start.yml
@@ -17,7 +17,7 @@ jobs:
       config-hash: ${{ steps.config-hash.outputs.config-hash }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
@@ -91,7 +91,7 @@ jobs:
             echo "title_word=Errored" >> $GITHUB_OUTPUT
             echo "gh_label=type:repro-error" >> $GITHUB_OUTPUT
             echo "gh_label_desc=Repro check error" >> $GITHUB_OUTPUT
-            
+
           fi
           config=${{ github.event.repository.name }}
           echo "config=$config" >> $GITHUB_OUTPUT

--- a/.github/workflows/generate-checksums.yml
+++ b/.github/workflows/generate-checksums.yml
@@ -52,7 +52,7 @@ jobs:
       config-hash: ${{ steps.config-hash.outputs.config-hash }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
@@ -125,7 +125,7 @@ jobs:
       ARTIFACT_LOCAL_LOCATION: /opt/artifact
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.config-branch-name }}
           fetch-depth: 0

--- a/.github/workflows/test-repro.yml
+++ b/.github/workflows/test-repro.yml
@@ -264,7 +264,7 @@ jobs:
 
       - name: Parse Test Report
         id: tests
-        uses: EnricoMi/publish-unit-test-result-action/composite@82082dac68ad6a19d980f8ce817e108b9f496c2a  #v2.17.1
+        uses: EnricoMi/publish-unit-test-result-action/linux@c950f6fb443cb5af20a377fd0dfaa78838901040  #v2.23.0
         with:
           files: ${{ env.TESTING_LOCAL_LOCATION }}/checksum/test_report.xml
           comment_mode: off


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## The PR

- **Update actions/checkout to v6**
- **Update actions/setup-python to v6**
- **Update EnricoMi/publish-unit-test-result-action to use non-composite action, updated to v2.23.0** - see https://github.com/EnricoMi/publish-unit-test-result-action/tree/v2#running-as-a-composite-action
