### PR TITLE
Add QA checks on ESM1.6 metadata fields.

### DIFF
--- a/src/model_config_tests/config_tests/qa/test_access_esm1p6_config.py
+++ b/src/model_config_tests/config_tests/qa/test_access_esm1p6_config.py
@@ -27,8 +27,8 @@ ACCESS_ESM1P6_REPOSITORY_NAME = "ACCESS-ESM1.6"
 VALID_REALMS: set[str] = {"atmos", "land", "ocean", "ocnBgchem", "seaIce"}
 VALID_KEYWORDS: set[str] = {"global", "access-esm1.6"}
 VALID_NOMINAL_RESOLUTION: str = "100 km"
-# TODO: Reference is pointing to ESM1.5 paper for now, update when ESM1.6 paper is ready
-VALID_REFERENCE_1p5: str = "https://doi.org/10.1071/ES19035"
+# TODO: Update this reference when ESM1.6 paper is ready
+VALID_REFERENCE_1p6: str = "https://doi.org/10.5281/zenodo.17490072"
 VALID_URL: str = "https://github.com/ACCESS-NRI/access-esm1.6-configs.git"
 VALID_RUNTIME: dict[str, int] = {"years": 1, "months": 0, "days": 0}
 VALID_RESTART_FREQ: str = "10YS"
@@ -153,7 +153,7 @@ class TestAccessEsm1p6:
             ("nominal_resolution", VALID_NOMINAL_RESOLUTION),
             ("model", ACCESS_ESM1P6_REPOSITORY_NAME),
             ("url", VALID_URL),
-            ("reference", VALID_REFERENCE_1p5),
+            ("reference", VALID_REFERENCE_1p6),
         ],
     )
     def test_metadata_field_equal_expected_value(self, field, expected, metadata):

--- a/src/model_config_tests/config_tests/qa/test_access_esm1p6_config.py
+++ b/src/model_config_tests/config_tests/qa/test_access_esm1p6_config.py
@@ -27,8 +27,9 @@ ACCESS_ESM1P6_REPOSITORY_NAME = "ACCESS-ESM1.6"
 VALID_REALMS: set[str] = {"atmos", "land", "ocean", "ocnBgchem", "seaIce"}
 VALID_KEYWORDS: set[str] = {"global", "access-esm1.6"}
 VALID_NOMINAL_RESOLUTION: str = "100 km"
-# TODO: Add back in when valid DOI for ESM1.6 is obtained
-# VALID_REFERENCE: str = "https://doi.org/10.1071/ES19035"
+# TODO: Reference is pointing to ESM1.5 paper for now, update when ESM1.6 paper is ready
+VALID_REFERENCE_1p5: str = "https://doi.org/10.1071/ES19035"
+VALID_URL: str = "https://github.com/ACCESS-NRI/access-esm1.6-configs.git"
 VALID_RUNTIME: dict[str, int] = {"years": 1, "months": 0, "days": 0}
 VALID_RESTART_FREQ: str = "10YS"
 VALID_MPPNCCOMBINE_EXE: str = "mppnccombine.spack"
@@ -150,14 +151,28 @@ class TestAccessEsm1p6:
         "field,expected",
         [
             ("nominal_resolution", VALID_NOMINAL_RESOLUTION),
-            # TODO: Add back in when valid DOI for ESM1.6 is obtained (see commented constant above)
-            # ("reference", VALID_REFERENCE),
+            ("model", ACCESS_ESM1P6_REPOSITORY_NAME),
+            ("url", VALID_URL),
+            ("reference", VALID_REFERENCE_1p5),
         ],
     )
     def test_metadata_field_equal_expected_value(self, field, expected, metadata):
         assert field in metadata and metadata[field] == expected, error_field_incorrect(
             field, "metadata.yaml", expected
         )
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            ("description"),
+            ("notes"),
+        ],
+    )
+    def test_metadata_not_contain_esm1p5(self, field, metadata):
+        """Check that some fields in metadata do not contain 'ESM1.5', e.g., notes and description."""
+        assert (
+            field in metadata and "ESM1.5" not in metadata[field]
+        ), f"Field '{field}' in metadata.yaml should not contain 'ESM1.5'. "
 
     def test_config_runtime(self, config):
         assert (

--- a/tests/common.py
+++ b/tests/common.py
@@ -40,13 +40,13 @@ CLONE_CONFIGS = {
     "esm1p6-amip": {
         "repo_url": "https://github.com/ACCESS-NRI/access-esm1.6-configs.git",
         "branch": "dev-amip",
-        "commit": "a875585",
+        "commit": "61bfbed",
     },
     # ACCESS-ESM1.6, branch: dev-preindustrial+concentrations
-    "esm1p6-prein": {
+    "esm1p6-piCtrl": {
         "repo_url": "https://github.com/ACCESS-NRI/access-esm1.6-configs.git",
         "branch": "dev-piControl",
-        "commit": "946134f",
+        "commit": "747d848",
     },
 }
 

--- a/tests/config_tests/qa/test_test_access_esm1p6_config.py
+++ b/tests/config_tests/qa/test_test_access_esm1p6_config.py
@@ -4,7 +4,7 @@ import subprocess
 
 def test_test_access_esm1p6_config_release_release_preindustrial(isolated_config):
     """Test ACCESS-ESM1.6 specific config tests"""
-    branch_name, config_dir = isolated_config("esm1p6-amip")
+    branch_name, config_dir = isolated_config("esm1p6-piCtrl")
 
     if not config_dir.exists():
         raise FileNotFoundError(f"The test configuration {config_dir} does not exist.")

--- a/tests/config_tests/test_model_extract_checksums.py
+++ b/tests/config_tests/test_model_extract_checksums.py
@@ -20,7 +20,7 @@ MODEL_NAMES = model_index.keys()
     [
         ("access", "esm1p5-prein", "output000", "checksums"),
         ("access-esm1.6", "esm1p6-amip", "amip-output000", "amip-checksums"),
-        ("access-esm1.6", "esm1p6-prein", "output000", "checksums"),
+        ("access-esm1.6", "esm1p6-piCtrl", "output000", "checksums"),
         ("access-om2", None, "output000", "checksums"),
         ("access-om3", None, "output000", "checksums"),
     ],


### PR DESCRIPTION
This PR add QA checks on metadata fields in ESM1.6 config repository, including:
- "model" == "ACCESS-ESM1.6"
- "url" == "https://github.com/ACCESS-NRI/access-esm1.6-configs.git"
- "reference" == "https://doi.org/10.5281/zenodo.17490072"
- "note" and "description" do not contain string `ESM1.5`

Closes #221 .