### PR TITLE
For PR workflows, use `github.event.pull_request.head.sha` rather than `github.sha`

### DIFF
--- a/.github/workflows/config-pr-1-ci.yml
+++ b/.github/workflows/config-pr-1-ci.yml
@@ -225,7 +225,7 @@ jobs:
     with:
       # FIXME: Make the environment name an input of some kind - what if we deploy to a different supercomputer?
       environment-name: Gadi
-      config-hash: ${{ github.sha }}
+      config-hash: ${{ github.event.pull_request.head.sha }}
       config-ref: ${{ github.head_ref }}
       compared-config-ref: ${{ needs.config.outputs.compared-config-tag }}
       test-markers: ${{ needs.config.outputs.repro-markers }}


### PR DESCRIPTION
## Background

See error https://github.com/ACCESS-NRI/access-esm1.6-configs/actions/runs/26791433362/job/78987492391#step:4:94

The PR workflow uses `github.sha` for `test-repro`s `inputs.config-hash`, but for pull request events, this resolves to the merge commit (a GitHub-specific creation), which isn't accessible to cloned repos. 

Rather than that, we should use `github.event.pull_request.head.sha`, which resolves to the `HEAD` of the PR branch. 

## The PR

* In the PR workflow, use `github.event.pull_request.head.sha`. 
