### PR TITLE
Print payu run error message; Update resource for unit test

### DIFF
--- a/src/model_config_tests/exp_test_helper.py
+++ b/src/model_config_tests/exp_test_helper.py
@@ -223,6 +223,7 @@ but `payu setup` will take longer to run as it needs to re-calculate all the md5
             # Change to experiment directory and run.
             os.chdir(self.control_path)
 
+            # Run payu setup command
             print("Running payu setup")
             result = sp.run(
                 ["payu", "setup", "--lab", str(self.lab_path)],
@@ -240,6 +241,7 @@ but `payu setup` will take longer to run as it needs to re-calculate all the md5
                 print(error_msg)
                 raise RuntimeError(error_msg)
 
+            # Run payu sweep command
             print("Running payu sweep")
             sp.run(
                 ["payu", "sweep", "--lab", str(self.lab_path)],
@@ -248,6 +250,7 @@ but `payu setup` will take longer to run as it needs to re-calculate all the md5
                 check=True,
             )
 
+            # Run payu run command
             run_command = ["payu", "run", "--lab", str(self.lab_path)]
             if n_runs:
                 run_command.extend(["--nruns", str(n_runs)])
@@ -255,8 +258,14 @@ but `payu setup` will take longer to run as it needs to re-calculate all the md5
             result = sp.run(run_command, capture_output=True, text=True, check=True)
             self.run_id = parse_run_id(result.stdout)
             print(f"Run Job ID: {self.run_id}")
+
         except sp.CalledProcessError as e:
-            raise RuntimeError(f"Failed to submit payu run. Error: {e}")
+            raise RuntimeError(
+                f"Failed to submit payu run:\n"
+                f"Return code: {e.returncode}\n"
+                f"--- stdout ---\n{e.stdout}\n"
+                f"--- stderr ---\n{e.stderr}"
+            )
         finally:
             # Change back to original working directory
             os.chdir(owd)

--- a/tests/common.py
+++ b/tests/common.py
@@ -15,8 +15,8 @@ CLONE_CONFIGS = {
     # ACCESS-OM2, branch: dev-025deg_jra55_iaf_bgc
     "om2-025deg": {
         "repo_url": "https://github.com/ACCESS-NRI/access-om2-configs.git",
-        "branch": "dev-025deg_jra55_iaf_bgc",
-        "commit": "bf3f0e2",
+        "branch": "release-025deg_jra55_iaf",
+        "commit": "28acc02",
     },
     # ACCESS-OM3, branch: dev-MC_100km_jra_ryf
     "om3-100km": {
@@ -27,8 +27,8 @@ CLONE_CONFIGS = {
     # ACCESS-OM3, branch: dev-MCW_100km_jra_ryf
     "om3-100km-wav": {
         "repo_url": "https://github.com/ACCESS-NRI/access-om3-configs.git",
-        "branch": "dev-MCW_100km_jra_ryf",
-        "commit": "d7a19b4",
+        "branch": "dev-MCW_100km_jra_iaf",
+        "commit": "f65fd4a",
     },
     # ACCESS-ESM1.5, branch: release-preindustrial+concentrations
     "esm1p5-prein": {

--- a/tests/test_exp_test_helper.py
+++ b/tests/test_exp_test_helper.py
@@ -196,17 +196,27 @@ def test_experiment_submit_payu_run_error(mock_run, exp):
     setup_success = Mock()
     setup_success.stdout = "Setup successful"
     setup_success.returncode = 0
+
+    run_return_code = 1
+    run_error_stdout = "Example stdout"
+    run_error_stderr = "Example stderr"
     mock_run.side_effect = [
         setup_success,
         subprocess.CalledProcessError(
-            returncode=1, cmd="payu run", output="Some error"
+            returncode=run_return_code,
+            cmd="payu run",
+            output=run_error_stdout,
+            stderr=run_error_stderr,
         ),
     ]
 
-    with pytest.raises(RuntimeError, match="Failed to submit payu run.*"):
+    with pytest.raises(RuntimeError, match="Failed to submit payu run.*") as exec_info:
         exp.submit_payu_run()
 
     assert exp.run_id is None
+    assert f"--- stdout ---\n{run_error_stdout}" in str(exec_info.value)
+    assert f"--- stderr ---\n{run_error_stderr}" in str(exec_info.value)
+    assert f"Return code: {run_return_code}" in str(exec_info.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR fixes two issues:
1. Print error message for `payu run` in subprocess. Closes #229.
2. Update the OM2 and OM3 resources for unit tests, since the previous branches are removed in the [OM2](https://github.com/ACCESS-NRI/access-om2-configs/issues/352) and [OM3](https://github.com/ACCESS-NRI/access-om3-configs/pull/1440) configs.