### PR TITLE
Separate test_test_repro_historical test to two small unit tests

### DIFF
--- a/tests/config_tests/test_model_set_model_runtime.py
+++ b/tests/config_tests/test_model_set_model_runtime.py
@@ -1,0 +1,160 @@
+import shutil
+from unittest.mock import Mock
+
+import f90nml
+import pytest
+import yaml
+from payu.models.cesm_cmeps import Runconfig
+
+from model_config_tests.models import index as model_index
+from tests.common import RESOURCES_DIR
+
+
+@pytest.fixture
+def model_factory(isolated_config, tmp_path):
+    """Factory fixture to create model instances with an isolated configuration."""
+
+    def factory(model_name, config_name, output):
+        resources_dir = RESOURCES_DIR / model_name
+
+        # Mock ExpTestHelper
+        mock_experiment = Mock()
+        mock_experiment.output000 = resources_dir / output
+        mock_experiment.restart000 = resources_dir / "restart000"
+
+        mock_experiment.control_path = tmp_path / "control"
+        _, config_dir = isolated_config(config_name)
+        shutil.move(config_dir, mock_experiment.control_path)
+
+        mock_experiment.config_path = tmp_path / "control" / "config.yaml"
+        with open(mock_experiment.config_path) as f:
+            mock_experiment.config = yaml.safe_load(f)
+
+        # Create Model instance
+        ModelType = model_index[model_name]
+        return ModelType(mock_experiment)
+
+    return factory
+
+
+@pytest.mark.parametrize(
+    "expected_runtime",
+    [
+        {"years": 1, "months": 2, "days": 3, "seconds": 0},
+        {"years": 0, "months": 1, "days": 5, "seconds": 0},
+    ],
+)
+def test_set_model_runtime_esm1p5(model_factory, expected_runtime):
+    """Test that ACCESS-ESM1p5 set_model_runtime sets the correct runtime in config.yaml"""
+    # Set up ACCESS-ESM1.5 model
+    model = model_factory(
+        model_name="access", config_name="esm1p5-prein", output="output000"
+    )
+
+    # Call set_model_runtime with the expected runtime
+    model.set_model_runtime(
+        years=expected_runtime["years"],
+        months=expected_runtime["months"],
+        seconds=expected_runtime["days"] * 24 * 3600,
+    )
+
+    # Check that the config.yaml file has been updated with the expected runtime
+    with open(model.experiment.config_path) as f:
+        updated_config = yaml.safe_load(f)
+    assert updated_config["calendar"]["runtime"] == expected_runtime
+
+    # Check that atmosphere has 48 timesteps per day
+    atmosphere_config = (
+        model.experiment.control_path / model.submodels["um"] / "namelists"
+    )
+    with open(atmosphere_config) as f:
+        atmosphere_nml = f90nml.read(f)
+    assert atmosphere_nml["NLSTCGEN"]["DUMPFREQim"] == [48, 0, 0, 0]
+
+    # Check that ice restarts at daily frequency
+    ice_config = model.experiment.control_path / model.submodels["cice"] / "cice_in.nml"
+    with open(ice_config) as f:
+        ice_nml = f90nml.read(f)
+    assert ice_nml["setup_nml"]["dumpfreq"] == "d"
+
+
+@pytest.mark.parametrize(
+    "expected_runtime, raise_error",
+    [
+        # two of years, months, seconds need to be zero
+        ([0, 0, 5 * 24 * 3600], False),  # 5 days in seconds
+        ([0, 1, 0], False),  # 1 month
+        (
+            [0, 1, 5 * 24 * 3600],
+            True,
+        ),  # 1 month and 5 days in seconds (should raise error)
+    ],
+)
+def test_set_model_runtime_om2(model_factory, expected_runtime, raise_error):
+    """Test that ACCESS-OM2 set_model_runtime sets the correct runtime in config.yaml"""
+    # Set up ACCESS-OM2 model
+    model = model_factory(
+        model_name="access-om2", config_name="om2-1deg", output="output000"
+    )
+
+    # Call set_model_runtime with the expected runtime
+    if raise_error:
+        with pytest.raises(
+            NotImplementedError,
+            match="Cannot specify runtime in seconds and years and months at the same time.",
+        ):
+            model.set_model_runtime(*expected_runtime)
+    else:
+        model.set_model_runtime(*expected_runtime)
+
+        # Check that the accessom2_config.yaml file has been updated with the expected runtime
+        with open(model.accessom2_config) as f:
+            nml = f90nml.read(f)
+        assert nml["date_manager_nml"]["restart_period"] == expected_runtime
+
+
+@pytest.mark.parametrize(
+    "expected_runtime, expected_freq, expected_n, raise_error",
+    [
+        ([0, 0, 10 * 3600], "nseconds", "36000", False),  # 10 hours in seconds
+        ([0, 1, 0], "nmonths", "1", False),  # 1 month
+        ([1, 0, 0], "nmonths", "12", False),  # 1 year
+        (
+            [0, 1, 10],
+            None,
+            None,
+            True,
+        ),  # Error: Cannot specify runtime in seconds and year/months at the same time
+    ],
+)
+def test_set_model_runtime_om3(
+    model_factory, expected_runtime, expected_freq, expected_n, raise_error
+):
+    """Test that ACCESS-OM3 set_model_runtime sets the correct runtime in config.yaml"""
+    # Set up ACCESS-OM3 model
+    model = model_factory(
+        model_name="access-om3", config_name="om3-100km", output="output000"
+    )
+
+    if raise_error:
+        with pytest.raises(
+            NotImplementedError,
+            match="Cannot specify runtime in seconds and year/months at the same time",
+        ):
+            model.set_model_runtime(*expected_runtime)
+    else:
+        # Call set_model_runtime with the expected runtime
+        model.set_model_runtime(*expected_runtime)
+
+        # Check that the accessom3_config.yaml file has been updated with the expected runtime
+        runconfig = Runconfig(model.runconfig)
+        assert runconfig.get("CLOCK_attributes", "restart_n") == expected_n
+        assert runconfig.get("CLOCK_attributes", "restart_option") == expected_freq
+        assert runconfig.get("CLOCK_attributes", "stop_n") == expected_n
+        assert runconfig.get("CLOCK_attributes", "stop_option") == expected_freq
+
+
+def test_set_model_runtime_esm1p6(model_factory):
+    """Test that ACCESS-ESM1.6 set_model_runtime updates the config.yaml correctly"""
+    # TODO: Update with release esm1.6 configurations when available
+    pass

--- a/tests/config_tests/test_model_set_model_runtime.py
+++ b/tests/config_tests/test_model_set_model_runtime.py
@@ -7,6 +7,12 @@ import yaml
 from payu.models.cesm_cmeps import Runconfig
 
 from model_config_tests.models import index as model_index
+from model_config_tests.models.accessesm1p5 import (
+    DEFAULT_RUNTIME_SECONDS as ESM_RUNTIME,
+)
+from model_config_tests.models.accessom2 import DEFAULT_RUNTIME_SECONDS as OM2_RUNTIME
+from model_config_tests.models.accessom3 import DEFAULT_RUNTIME_SECONDS as OM3_RUNTIME
+from model_config_tests.util import DAY_IN_SECONDS
 from tests.common import RESOURCES_DIR
 
 
@@ -38,13 +44,22 @@ def model_factory(isolated_config, tmp_path):
 
 
 @pytest.mark.parametrize(
-    "expected_runtime",
+    "expected_runtime, default",
     [
-        {"years": 1, "months": 2, "days": 3, "seconds": 0},
-        {"years": 0, "months": 1, "days": 5, "seconds": 0},
+        ({"years": 1, "months": 2, "days": 3, "seconds": 0}, False),
+        ({"years": 0, "months": 1, "days": 5, "seconds": 0}, False),
+        (
+            {
+                "years": 0,
+                "months": 0,
+                "days": ESM_RUNTIME / DAY_IN_SECONDS,
+                "seconds": 0,
+            },
+            True,
+        ),
     ],
 )
-def test_set_model_runtime_esm1p5(model_factory, expected_runtime):
+def test_set_model_runtime_esm1p5(model_factory, expected_runtime, default):
     """Test that ACCESS-ESM1p5 set_model_runtime sets the correct runtime in config.yaml"""
     # Set up ACCESS-ESM1.5 model
     model = model_factory(
@@ -52,45 +67,49 @@ def test_set_model_runtime_esm1p5(model_factory, expected_runtime):
     )
 
     # Call set_model_runtime with the expected runtime
-    model.set_model_runtime(
-        years=expected_runtime["years"],
-        months=expected_runtime["months"],
-        seconds=expected_runtime["days"] * 24 * 3600,
-    )
+    if default:
+        # If default is True, we expect the default runtime to be set
+        model.set_model_runtime()
+    else:
+        model.set_model_runtime(
+            years=expected_runtime["years"],
+            months=expected_runtime["months"],
+            seconds=expected_runtime["days"] * DAY_IN_SECONDS,
+        )
 
     # Check that the config.yaml file has been updated with the expected runtime
     with open(model.experiment.config_path) as f:
         updated_config = yaml.safe_load(f)
     assert updated_config["calendar"]["runtime"] == expected_runtime
 
-    # Check that atmosphere has 48 timesteps per day
-    atmosphere_config = (
-        model.experiment.control_path / model.submodels["um"] / "namelists"
-    )
+    # Check that atmosphere has 48 timesteps per day, hard-coded the path to check if the path changes
+    atmosphere_config = model.experiment.control_path / "atmosphere" / "namelists"
     with open(atmosphere_config) as f:
         atmosphere_nml = f90nml.read(f)
     assert atmosphere_nml["NLSTCGEN"]["DUMPFREQim"] == [48, 0, 0, 0]
 
-    # Check that ice restarts at daily frequency
-    ice_config = model.experiment.control_path / model.submodels["cice"] / "cice_in.nml"
+    # Check that ice restarts at daily frequency, hard-coded the path to check if the path changes
+    ice_config = model.experiment.control_path / "ice" / "cice_in.nml"
     with open(ice_config) as f:
         ice_nml = f90nml.read(f)
     assert ice_nml["setup_nml"]["dumpfreq"] == "d"
 
 
 @pytest.mark.parametrize(
-    "expected_runtime, raise_error",
+    "expected_runtime, raise_error, default",
     [
         # two of years, months, seconds need to be zero
-        ([0, 0, 5 * 24 * 3600], False),  # 5 days in seconds
-        ([0, 1, 0], False),  # 1 month
+        ([0, 0, 5 * DAY_IN_SECONDS], False, False),  # 5 days in seconds
+        ([0, 1, 0], False, False),  # 1 month
         (
-            [0, 1, 5 * 24 * 3600],
+            [0, 1, 5 * DAY_IN_SECONDS],
             True,
+            False,
         ),  # 1 month and 5 days in seconds (should raise error)
+        ([0, 0, OM2_RUNTIME], False, True),  # Default runtime in seconds
     ],
 )
-def test_set_model_runtime_om2(model_factory, expected_runtime, raise_error):
+def test_set_model_runtime_om2(model_factory, expected_runtime, raise_error, default):
     """Test that ACCESS-OM2 set_model_runtime sets the correct runtime in config.yaml"""
     # Set up ACCESS-OM2 model
     model = model_factory(
@@ -105,7 +124,10 @@ def test_set_model_runtime_om2(model_factory, expected_runtime, raise_error):
         ):
             model.set_model_runtime(*expected_runtime)
     else:
-        model.set_model_runtime(*expected_runtime)
+        if default:
+            model.set_model_runtime()
+        else:
+            model.set_model_runtime(*expected_runtime)
 
         # Check that the accessom2_config.yaml file has been updated with the expected runtime
         with open(model.accessom2_config) as f:
@@ -114,21 +136,29 @@ def test_set_model_runtime_om2(model_factory, expected_runtime, raise_error):
 
 
 @pytest.mark.parametrize(
-    "expected_runtime, expected_freq, expected_n, raise_error",
+    "expected_runtime, expected_freq, expected_n, raise_error, default",
     [
-        ([0, 0, 10 * 3600], "nseconds", "36000", False),  # 10 hours in seconds
-        ([0, 1, 0], "nmonths", "1", False),  # 1 month
-        ([1, 0, 0], "nmonths", "12", False),  # 1 year
+        ([0, 0, 10 * 3600], "nseconds", "36000", False, False),  # 10 hours in seconds
+        ([0, 1, 0], "nmonths", "1", False, False),  # 1 month
+        ([1, 0, 0], "nmonths", "12", False, False),  # 1 year
         (
             [0, 1, 10],
             None,
             None,
             True,
+            False,
         ),  # Error: Cannot specify runtime in seconds and year/months at the same time
+        (
+            [0, 0, OM3_RUNTIME],
+            "nseconds",
+            f"{OM3_RUNTIME}",
+            False,
+            True,
+        ),  # Default runtime in seconds
     ],
 )
 def test_set_model_runtime_om3(
-    model_factory, expected_runtime, expected_freq, expected_n, raise_error
+    model_factory, expected_runtime, expected_freq, expected_n, raise_error, default
 ):
     """Test that ACCESS-OM3 set_model_runtime sets the correct runtime in config.yaml"""
     # Set up ACCESS-OM3 model
@@ -144,7 +174,10 @@ def test_set_model_runtime_om3(
             model.set_model_runtime(*expected_runtime)
     else:
         # Call set_model_runtime with the expected runtime
-        model.set_model_runtime(*expected_runtime)
+        if default:
+            model.set_model_runtime()
+        else:
+            model.set_model_runtime(*expected_runtime)
 
         # Check that the accessom3_config.yaml file has been updated with the expected runtime
         runconfig = Runconfig(model.runconfig)

--- a/tests/config_tests/test_test_bit_reproducibility.py
+++ b/tests/config_tests/test_test_bit_reproducibility.py
@@ -7,9 +7,7 @@ import warnings
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-import f90nml
 import pytest
-import yaml
 from netCDF4 import Dataset
 from payu.models.cesm_cmeps import Runconfig
 
@@ -24,7 +22,7 @@ from model_config_tests.models.accessesm1p5 import (
 )
 from model_config_tests.models.accessom2 import DEFAULT_RUNTIME_SECONDS as OM2_RUNTIME
 from model_config_tests.models.accessom3 import DEFAULT_RUNTIME_SECONDS as OM3_RUNTIME
-from model_config_tests.util import DAY_IN_SECONDS, HOUR_IN_SECONDS
+from model_config_tests.util import HOUR_IN_SECONDS
 
 
 def exp_test_helper_factory(*args, **kwargs):
@@ -406,17 +404,6 @@ def test_test_repro_historical(
 
     assert result.returncode == int(fail)
 
-    # Check runtime is set correctly
-    check_runtime(helper.test_control_path, helper.model_name)
-
-    # Check general config.yaml settings for test
-    with open(helper.test_control_path / "config.yaml") as f:
-        test_config = yaml.safe_load(f)
-    assert test_config["experiment"] == exp_name
-    assert not test_config["runlog"]
-    assert not test_config["metadata"]["enable"]
-    assert test_config["laboratory"] == str(helper.lab_path)
-
     # Check name of checksum file written out and contents
     check_checksum(
         helper.output_path, checksum_path, helper.model_name, match=(not fail)
@@ -458,39 +445,6 @@ def test_test_access_om3_ocean_model(tmp_dir, isolated_config):
         "ACCESS-OM3 reproducibility checks utilize checksums written in MOM6 restarts"
     )
     assert error_msg in result.stdout
-
-
-def check_runtime(control_path, model_name):
-    if model_name in ["access", "access-esm1.6"]:
-        with open(control_path / "config.yaml") as f:
-            test_config = yaml.safe_load(f)
-        assert test_config["calendar"]["runtime"] == {
-            "years": 0,
-            "months": 0,
-            "days": ESM_RUNTIME / DAY_IN_SECONDS,
-            "seconds": 0,
-        }
-    elif model_name == "access-om2":
-        with open(control_path / "accessom2.nml") as f:
-            nml = f90nml.read(f)
-        years, months, seconds = nml["date_manager_nml"]["restart_period"]
-        assert years == 0
-        assert months == 0
-        assert seconds == OM2_RUNTIME
-    elif model_name == "access-om3":
-        runconfig = Runconfig(control_path / "nuopc.runconfig")
-        assert runconfig.get("CLOCK_attributes", "restart_option") == "nseconds"
-        assert int(runconfig.get("CLOCK_attributes", "restart_n")) == OM3_RUNTIME
-        assert runconfig.get("CLOCK_attributes", "stop_option") == "nseconds"
-        assert int(runconfig.get("CLOCK_attributes", "stop_n")) == OM3_RUNTIME
-
-        wav_in = control_path / "wav_in"
-        if wav_in.exists():
-            with open(wav_in) as f:
-                nml = f90nml.read(f)
-            assert nml["output_date_nml"]["date"]["restart"]["stride"] == OM3_RUNTIME
-    else:
-        raise ValueError(f"Unrecognised model: {model_name}")
 
 
 def check_checksum(output_path, checksum_path, model_name, match=True):

--- a/tests/test_exp_test_helper.py
+++ b/tests/test_exp_test_helper.py
@@ -14,6 +14,7 @@ from model_config_tests.exp_test_helper import (
     parse_gadi_pbs_ids,
     parse_pbs_submitted_jobs,
     parse_run_id,
+    setup_exp,
     wait_for_payu_jobs,
 )
 from model_config_tests.models.accessom3 import AccessOm3
@@ -656,3 +657,44 @@ index abc123...zyx789 100111
 
     # assert returning to the original work directory
     assert Path.cwd() == owd
+
+
+@pytest.mark.parametrize(
+    "model_name, config_name, control_name, expected_exp_name",
+    [
+        # ACCESS-ESM1.5 models
+        ("access", "esm1p5-prein", "control", "control-test_exp"),
+        ("access", "esm1p5-prein", "base-experiment", "test_exp"),
+        # ACCESS-OM2 models
+        ("access-om2", "om2-1deg", "control", "control-test_exp"),
+        ("access-om2", "om2-1deg", "base-experiment", "test_exp"),
+        # ACCESS-OM3 models
+        ("access-om3", "om3-100km", "control", "control-test_exp"),
+        ("access-om3", "om3-100km", "base-experiment", "test_exp"),
+    ],
+)
+def test_setup_exp_correct_config(
+    tmp_path, isolated_config, model_name, config_name, control_name, expected_exp_name
+):
+    """Test that setup_exp writes correct information into the config file"""
+    # Set up control and output directories
+    control_path = tmp_path / control_name
+    control_path.mkdir()
+    output_path = tmp_path / "output"
+    output_path.mkdir()
+
+    # Copy the config.yaml from the isolated config directory to the control path
+    _, config_dir = isolated_config(config_name)
+    shutil.move(str(config_dir / "config.yaml"), control_path / "config.yaml")
+
+    # Run the setup_exp function
+    exp = setup_exp(
+        control_path=control_path, output_path=output_path, exp_name="test_exp"
+    )
+
+    # Check that the config file has the expected values
+    config = yaml.safe_load(exp.config_path.open())
+    assert config["experiment"] == expected_exp_name
+    assert not config["runlog"]
+    assert not config["metadata"]["enable"]
+    assert config["laboratory"] == str(exp.lab_path)

--- a/tests/test_exp_test_helper.py
+++ b/tests/test_exp_test_helper.py
@@ -660,21 +660,15 @@ index abc123...zyx789 100111
 
 
 @pytest.mark.parametrize(
-    "model_name, config_name, control_name, expected_exp_name",
+    "config_name, control_name, expected_exp_name",
     [
-        # ACCESS-ESM1.5 models
-        ("access", "esm1p5-prein", "control", "control-test_exp"),
-        ("access", "esm1p5-prein", "base-experiment", "test_exp"),
-        # ACCESS-OM2 models
-        ("access-om2", "om2-1deg", "control", "control-test_exp"),
-        ("access-om2", "om2-1deg", "base-experiment", "test_exp"),
-        # ACCESS-OM3 models
-        ("access-om3", "om3-100km", "control", "control-test_exp"),
-        ("access-om3", "om3-100km", "base-experiment", "test_exp"),
+        # Use ACCESS-ESM1.5 models. Since there is no model-specifi logic, only pick one model to test
+        ("esm1p5-prein", "control", "control-test_exp"),
+        ("esm1p5-prein", "base-experiment", "test_exp"),
     ],
 )
 def test_setup_exp_correct_config(
-    tmp_path, isolated_config, model_name, config_name, control_name, expected_exp_name
+    tmp_path, isolated_config, config_name, control_name, expected_exp_name
 ):
     """Test that setup_exp writes correct information into the config file"""
     # Set up control and output directories


### PR DESCRIPTION
Previously `test_test_repro_historical` is a mixed test of `setup_exp` and historical repro test.

This PR adds a separate unit tests on `setup_exp` only. This PR additionally adds a separate file to test `set_model_runtime` of ACCESS-ESM1.5, ACCESS-OM2, and ACCESS-OM3.

Closes #115.

