### PR TITLE
Check input md5 hash with model-config-inputs repository.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "jsonschema >=4.21.1",
     "payu >=1.1.3",
     "pytest-sugar",
-    "netCDF4"
+    "netCDF4",
+    "yamanifest",
 ]
 
 [project.optional-dependencies]

--- a/src/model_config_tests/config_tests/qa/test_config.py
+++ b/src/model_config_tests/config_tests/qa/test_config.py
@@ -29,10 +29,14 @@ LICENSE_URL = "https://creativecommons.org/licenses/by/4.0/legalcode.txt"
 RELEASE_MODULE_LOCATION = "/g/data/vk83/modules"
 
 # Model config inputs repository for input file MD5 verification
-MODEL_CONFIG_INPUTS_REPO = "https://github.com/ACCESS-NRI/model-config-inputs"
 MODEL_CONFIG_INPUTS_RAW_URL = (
     "https://raw.githubusercontent.com/ACCESS-NRI/model-config-inputs/main"
 )
+
+
+class ManifestNotFoundError(Exception):
+    """Raised when a .manifest.yaml file does not exist (HTTP 404) at the
+    expected location in the model-config-inputs repository."""
 
 
 def insist_array(str_or_array):
@@ -452,6 +456,8 @@ def _cache_manifest_from_input_repo(manifest_url, manifest_cache):
     # Only fetch the manifest file if it is not already cached
     if manifest_url not in manifest_cache:
         response = requests.get(manifest_url)
+        if response.status_code == 404:
+            raise ManifestNotFoundError(f"URL not found: {manifest_url}")
         if response.status_code != 200:
             raise RuntimeError(
                 f"Failed to fetch manifest file from {manifest_url}: "
@@ -504,8 +510,10 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
     )  # {manifest_url1: manifest_data1, manifest_url2: manifest_data2, ...}, cached from input repo
 
     for fullpath in fullpaths:
-        # Check if fullpath is a file
-        if Path(fullpath).is_file():
+        # Try treating fullpath as a file first: the manifest lives in its
+        # parent directory. If no manifest is found there (404), fall back to
+        # treating fullpath as a directory where manifest lives.
+        try:
             # Build the manifest file url on the model-config-inputs repo
             path = fullpath.split("/inputs/")[-1]
             manifest_url = (
@@ -525,9 +533,8 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
             md5hash = _extract_md5_from_repo_response(fullpath, file_info, manifest_url)
             model_config_input[fullpath] = md5hash
 
-        # If full path is a directory
-        elif Path(fullpath).is_dir():
-            # Build the manifest file url on the model-config-inputs repo
+        # If no manifest was found assuming fullpath is a file, treat it as a directory
+        except ManifestNotFoundError:
             path = fullpath.split("/inputs/")[-1]
             manifest_url = f"{MODEL_CONFIG_INPUTS_RAW_URL}/{path}/.manifest.yaml"
 
@@ -546,6 +553,11 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
                     complete_fullpath, file_info, manifest_url
                 )
                 model_config_input[complete_fullpath] = md5hash
+
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to fetch MD5 hash for {fullpath} from model-config-inputs repo: {e}"
+            )
 
     return model_config_input
 

--- a/src/model_config_tests/config_tests/qa/test_config.py
+++ b/src/model_config_tests/config_tests/qa/test_config.py
@@ -462,15 +462,15 @@ def _cache_manifest_from_input_repo(manifest_url, manifest_cache, fullpath):
             )
 
         if response.status_code == 404:
-            raise ManifestNotFoundError(f"While checking input file: {fullpath},\n URL not found at {manifest_url}")
+            raise ManifestNotFoundError(
+                f"While checking input file: {fullpath},\n URL not found at {manifest_url}"
+            )
         if response.status_code != 200:
             raise RuntimeError(
                 f"Failed to fetch manifest file from {manifest_url}: "
                 f"HTTP {response.status_code}"
             )
-        assert response.text, (
-            f"Manifest file from {manifest_url} is empty."
-        )
+        assert response.text, f"Manifest file from {manifest_url} is empty."
 
         # YAML manifest files have headers and data, separated by `---`
         # The actual data is after the --- separator
@@ -537,7 +537,10 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
 
             # Extract the md5 hash for the current fullpath file
             md5hash = _extract_md5_from_repo_response(fullpath, file_info, manifest_url)
-            model_config_input[fullpath] = {"md5hash": md5hash, "repo_url": manifest_url}
+            model_config_input[fullpath] = {
+                "md5hash": md5hash,
+                "repo_url": manifest_url,
+            }
 
         # If no manifest was found assuming fullpath is a file, treat it as a directory
         except ManifestNotFoundError:
@@ -558,7 +561,10 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
                 md5hash = _extract_md5_from_repo_response(
                     complete_fullpath, file_info, manifest_url
                 )
-                model_config_input[complete_fullpath] = {"md5hash": md5hash, "repo_url": manifest_url}
+                model_config_input[complete_fullpath] = {
+                    "md5hash": md5hash,
+                    "repo_url": manifest_url,
+                }
 
         except Exception as e:
             raise RuntimeError(
@@ -600,9 +606,9 @@ def compare_input_md5_hashes(
 
     # Compare hashes for each input file
     for fullpath, repo_response in repo_hashes.items():
-        assert fullpath in local_input, (
-            f"Expected local input manifest to include input file:  {fullpath}"
-        )
+        assert (
+            fullpath in local_input
+        ), f"Expected local input manifest to include input file:  {fullpath}"
         local_hash = local_input.get(fullpath)
 
         repo_hash = repo_response.get("md5hash")
@@ -633,13 +639,13 @@ def check_allowed_config_location(
 
         # Check if a release branch is using prerelease input files
         if path.startswith(MODEL_CONFIG_INPUTS_PRERELEASE):
-            assert branch_type != "release", (
-                f"Input file {path} is in prerelease location, which is not allowed for release branches. "
-            )
+            assert (
+                branch_type != "release"
+            ), f"Input file {path} is in prerelease location, which is not allowed for release branches. "
         else:
             # Check if input file is in a published data project location
-            assert any(path.startswith(loc) for loc in PUBLISH_DATA_LOCATION), (
-                f"Input file {path} is not in vk83 or a published data project location: {PUBLISH_DATA_LOCATION}. "
-            )
+            assert any(
+                path.startswith(loc) for loc in PUBLISH_DATA_LOCATION
+            ), f"Input file {path} is not in vk83 or a published data project location: {PUBLISH_DATA_LOCATION}. "
 
     return filter_fps

--- a/src/model_config_tests/config_tests/qa/test_config.py
+++ b/src/model_config_tests/config_tests/qa/test_config.py
@@ -30,7 +30,9 @@ RELEASE_MODULE_LOCATION = "/g/data/vk83/modules"
 
 # Model config inputs repository for input file MD5 verification
 MODEL_CONFIG_INPUTS_REPO = "https://github.com/ACCESS-NRI/model-config-inputs"
-MODEL_CONFIG_INPUTS_RAW_URL = "https://raw.githubusercontent.com/ACCESS-NRI/model-config-inputs/main"
+MODEL_CONFIG_INPUTS_RAW_URL = (
+    "https://raw.githubusercontent.com/ACCESS-NRI/model-config-inputs/main"
+)
 
 
 def insist_array(str_or_array):
@@ -98,7 +100,7 @@ class TestRelConfig:
         )
 
     def test_manifest_input_match_repo(self, control_path, config):
-        """Check that input file MD5 hashes in manifests/input.yaml match 
+        """Check that input file MD5 hashes in manifests/input.yaml match
         those from model-config-inputs repository"""
         compare_input_md5_hashes(control_path, config)
 
@@ -393,14 +395,20 @@ def read_input_fullpaths_from_config(config: dict[str, Any]) -> list[str]:
     # Get top-level input paths
     if "input" in config:
         input_paths = insist_array(config["input"])
-        input_paths = [p.replace("/g/data/vk83/experiments", "/g/data/vk83/configurations") for p in input_paths]
+        input_paths = [
+            p.replace("/g/data/vk83/experiments", "/g/data/vk83/configurations")
+            for p in input_paths
+        ]
         fullpaths.extend(input_paths)
 
     # Get submodel input paths
     for submodel in config.get("submodels", []):
         if "input" in submodel:
             submodel_input_paths = insist_array(submodel["input"])
-            submodel_input_paths = [p.replace("/g/data/vk83/experiments", "/g/data/vk83/configurations") for p in submodel_input_paths]
+            submodel_input_paths = [
+                p.replace("/g/data/vk83/experiments", "/g/data/vk83/configurations")
+                for p in submodel_input_paths
+            ]
             fullpaths.extend(submodel_input_paths)
 
     return fullpaths
@@ -430,7 +438,9 @@ def read_manifest_input_hashes(control_path: Path) -> dict[str, str]:
     local_input = {}
     for _, file_info in data.items():
         fullpath = file_info.get("fullpath")
-        fullpath = fullpath.replace("/g/data/vk83/experiments", "/g/data/vk83/configurations")
+        fullpath = fullpath.replace(
+            "/g/data/vk83/experiments", "/g/data/vk83/configurations"
+        )
         md5hash = file_info.get("hashes", {}).get("md5", None)
         local_input[fullpath] = md5hash
 
@@ -443,9 +453,9 @@ def cache_manifest_from_input_repo(manifest_url, manifest_cache):
     if manifest_url not in manifest_cache:
         response = requests.get(manifest_url)
         assert response.status_code == 200, (
-                f"Failed to fetch manifest file from {manifest_url}: "
-                f"HTTP {response.status_code}"
-            )
+            f"Failed to fetch manifest file from {manifest_url}: "
+            f"HTTP {response.status_code}"
+        )
         # YAML manifest files have headers and data, separated by `---`
         # The actual data is after the --- separator
         docs = list(yaml.safe_load_all(response.text))
@@ -466,9 +476,10 @@ def _extract_md5_from_repo_response(fullpath, file_info, manifest_url):
             f"Fullpath in config.yaml \"{fullpath}\" does not match the one \"{file_info.get('fullpath')}\" in model-config-inputs repo {manifest_url}."
         )
 
+
 def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
     """Fetch MD5 hashes for input files from model-config-inputs repository.
-    
+
     The repo contains .manifest.yaml files that store MD5 hashes for input files.
     Path mapping: /g/data/vk83/configurations/inputs/access-om2/subdir/file.nc
     maps to: access-om2/subdir/.manifest.yaml
@@ -484,17 +495,23 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
         Dictionary mapping fullpath to MD5 hash from repo
     """
     model_config_input = {}
-    manifest_cache = {}  # {manifest_url1: manifest_data1, manifest_url2: manifest_data2, ...}, cached from input repo
+    manifest_cache = (
+        {}
+    )  # {manifest_url1: manifest_data1, manifest_url2: manifest_data2, ...}, cached from input repo
 
     for fullpath in fullpaths:
         # Check if fullpath is a file
         if Path(fullpath).is_file():
             # Build the manifest file url on the model-config-inputs repo
             path = fullpath.split("/inputs/")[-1]
-            manifest_url = f"{MODEL_CONFIG_INPUTS_RAW_URL}/{Path(path).parent}/.manifest.yaml"
-        
+            manifest_url = (
+                f"{MODEL_CONFIG_INPUTS_RAW_URL}/{Path(path).parent}/.manifest.yaml"
+            )
+
             # Cache the manifest file from model-config-inputs repo
-            manifest_cache = cache_manifest_from_input_repo(manifest_url, manifest_cache)
+            manifest_cache = cache_manifest_from_input_repo(
+                manifest_url, manifest_cache
+            )
 
             # Extract the input information for the current fullpath
             file_name = Path(fullpath).name
@@ -511,7 +528,9 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
             manifest_url = f"{MODEL_CONFIG_INPUTS_RAW_URL}/{path}/.manifest.yaml"
 
             # Cache the manifest file from model-config-inputs repo
-            manifest_cache = cache_manifest_from_input_repo(manifest_url, manifest_cache)
+            manifest_cache = cache_manifest_from_input_repo(
+                manifest_url, manifest_cache
+            )
 
             # Extract all fullpath and md5 hashes in this manifest file
             for file_name, file_info in manifest_cache[manifest_url].items():
@@ -519,7 +538,9 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
                 complete_fullpath = f"{fullpath}/{file_name}"
 
                 # Extract the md5 hash for each file in the directory
-                md5hash = _extract_md5_from_repo_response(complete_fullpath, file_info, manifest_url)
+                md5hash = _extract_md5_from_repo_response(
+                    complete_fullpath, file_info, manifest_url
+                )
                 model_config_input[complete_fullpath] = md5hash
 
     return model_config_input

--- a/src/model_config_tests/config_tests/qa/test_config.py
+++ b/src/model_config_tests/config_tests/qa/test_config.py
@@ -28,6 +28,10 @@ LICENSE_URL = "https://creativecommons.org/licenses/by/4.0/legalcode.txt"
 # Release modules location on NCI
 RELEASE_MODULE_LOCATION = "/g/data/vk83/modules"
 
+# Model config inputs repository for input file MD5 verification
+MODEL_CONFIG_INPUTS_REPO = "https://github.com/ACCESS-NRI/model-config-inputs"
+MODEL_CONFIG_INPUTS_RAW_URL = "https://raw.githubusercontent.com/ACCESS-NRI/model-config-inputs/main"
+
 
 def insist_array(str_or_array):
     if isinstance(str_or_array, str):
@@ -92,6 +96,11 @@ class TestRelConfig:
             "Executable reproducibility should be enforced, e.g set:\n"
             + "manifest:\n    reproduce:\n        exe: True"
         )
+
+    def test_manifest_input_match_repo(self, control_path, config):
+        """Check that input file MD5 hashes in manifests/input.yaml match 
+        those from model-config-inputs repository"""
+        compare_input_md5_hashes(control_path, config)
 
     def test_metadata_is_enabled(self, config):
         if "metadata" in config and "enable" in config["metadata"]:
@@ -363,4 +372,188 @@ def check_manifest_exes_in_spack_location(
             f"Expected 'exe: {exe_name}' for model/submodel in config.yaml. "
             "Only the name of the executable is needed, as the full path is "
             f"determined by payu (which searches PATHs added by {model_module_name} module)"
+        )
+
+
+def read_input_fullpaths_from_config(config: dict[str, Any]) -> list[str]:
+    """Extract all input file fullpaths from config.yaml.
+
+    Parameters
+    ----------
+    config : Dict[str, Any]
+        The contents of the config.yaml file
+
+    Returns
+    -------
+    list[str]
+        List of fullpaths to input files
+    """
+    fullpaths = []
+
+    # Get top-level input paths
+    if "input" in config:
+        input_paths = insist_array(config["input"])
+        input_paths = [p.replace("/g/data/vk83/experiments", "/g/data/vk83/configurations") for p in input_paths]
+        fullpaths.extend(input_paths)
+
+    # Get submodel input paths
+    for submodel in config.get("submodels", []):
+        if "input" in submodel:
+            submodel_input_paths = insist_array(submodel["input"])
+            submodel_input_paths = [p.replace("/g/data/vk83/experiments", "/g/data/vk83/configurations") for p in submodel_input_paths]
+            fullpaths.extend(submodel_input_paths)
+
+    return fullpaths
+
+
+def read_manifest_input_hashes(control_path: Path) -> dict[str, str]:
+    """Read MD5 hashes from manifests/input.yaml.
+
+    Parameters
+    ----------
+    control_path : Path
+        Path to the local control directory containing the manifest file
+
+    Returns
+    -------
+    dict[str, str]
+        Dictionary mapping fullpath to MD5 hash
+    """
+
+    # This YAML manifest files have headers and data, separated by `---`
+    # The actual data is after the --- separator
+    manifest_path = control_path / "manifests" / "input.yaml"
+    with open(manifest_path) as f:
+        docs = list(yaml.safe_load_all(f))
+    data = docs[-1] if docs else {}
+
+    local_input = {}
+    for _, file_info in data.items():
+        fullpath = file_info.get("fullpath")
+        fullpath = fullpath.replace("/g/data/vk83/experiments", "/g/data/vk83/configurations")
+        md5hash = file_info.get("hashes", {}).get("md5", None)
+        local_input[fullpath] = md5hash
+
+    return local_input
+
+
+def cache_manifest_from_input_repo(manifest_url, manifest_cache):
+    """Fetch and cache the manifest file from model-config-inputs repository."""
+    # Only fetch the manifest file if it is not already cached
+    if manifest_url not in manifest_cache:
+        response = requests.get(manifest_url)
+        assert response.status_code == 200, (
+                f"Failed to fetch manifest file from {manifest_url}: "
+                f"HTTP {response.status_code}"
+            )
+        # YAML manifest files have headers and data, separated by `---`
+        # The actual data is after the --- separator
+        docs = list(yaml.safe_load_all(response.text))
+        manifest_cache[manifest_url] = docs[-1] if docs else {}
+
+    return manifest_cache
+
+
+def _extract_md5_from_repo_response(fullpath, file_info, manifest_url):
+    """Extract the md5 hash for a given fullpath from the manifest file fetched from the model-config-inputs repository."""
+    # Check if the fullpath in the input repo matches the fullpath from config.yaml
+    if fullpath == file_info.get("fullpath"):
+        return file_info.get("hashes", {}).get("md5", None)
+
+    else:
+        # If fullpath not matching, raise an error
+        raise RuntimeError(
+            f"Fullpath in config.yaml \"{fullpath}\" does not match the one \"{file_info.get('fullpath')}\" in model-config-inputs repo {manifest_url}."
+        )
+
+def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
+    """Fetch MD5 hashes for input files from model-config-inputs repository.
+    
+    The repo contains .manifest.yaml files that store MD5 hashes for input files.
+    Path mapping: /g/data/vk83/configurations/inputs/access-om2/subdir/file.nc
+    maps to: access-om2/subdir/.manifest.yaml
+
+    Parameters
+    ----------
+    fullpaths : list[str]
+        List of fullpaths to input files
+
+    Returns
+    -------
+    dict[str, str]
+        Dictionary mapping fullpath to MD5 hash from repo
+    """
+    model_config_input = {}
+    manifest_cache = {}  # {manifest_url1: manifest_data1, manifest_url2: manifest_data2, ...}, cached from input repo
+
+    for fullpath in fullpaths:
+        # Check if fullpath is a file
+        if Path(fullpath).is_file():
+            # Build the manifest file url on the model-config-inputs repo
+            path = fullpath.split("/inputs/")[-1]
+            manifest_url = f"{MODEL_CONFIG_INPUTS_RAW_URL}/{Path(path).parent}/.manifest.yaml"
+        
+            # Cache the manifest file from model-config-inputs repo
+            manifest_cache = cache_manifest_from_input_repo(manifest_url, manifest_cache)
+
+            # Extract the input information for the current fullpath
+            file_name = Path(fullpath).name
+            file_info = manifest_cache[manifest_url].get(file_name, {})
+
+            # Extract the md5 hash for the current fullpath file
+            md5hash = _extract_md5_from_repo_response(fullpath, file_info, manifest_url)
+            model_config_input[fullpath] = md5hash
+
+        # If full path is a directory
+        elif Path(fullpath).is_dir():
+            # Build the manifest file url on the model-config-inputs repo
+            path = fullpath.split("/inputs/")[-1]
+            manifest_url = f"{MODEL_CONFIG_INPUTS_RAW_URL}/{path}/.manifest.yaml"
+
+            # Cache the manifest file from model-config-inputs repo
+            manifest_cache = cache_manifest_from_input_repo(manifest_url, manifest_cache)
+
+            # Extract all fullpath and md5 hashes in this manifest file
+            for file_name, file_info in manifest_cache[manifest_url].items():
+                # Build the complete fullpath for each file in the directory
+                complete_fullpath = f"{fullpath}/{file_name}"
+
+                # Extract the md5 hash for each file in the directory
+                md5hash = _extract_md5_from_repo_response(complete_fullpath, file_info, manifest_url)
+                model_config_input[complete_fullpath] = md5hash
+
+    return model_config_input
+
+
+def compare_input_md5_hashes(control_path: Path, config: dict[str, Any]):
+    """Check that input file MD5 hashes match those in manifests/input.yaml
+    and from model-config-inputs repository.
+
+    Parameters
+    ----------
+    control_path : Path
+        Path to the model configuration directory
+    config : Dict[str, Any]
+        The contents of the config.yaml file
+
+    Raises
+    ------
+    AssertionError
+        If MD5 hashes do not match or files are not found
+    """
+    # Get input fullpaths from config.yaml
+    fullpaths = read_input_fullpaths_from_config(config)
+
+    # Read local MD5 hashes from manifests/input.yaml
+    local_input = read_manifest_input_hashes(control_path)
+
+    # Fetch MD5 hashes from model-config-inputs repo
+    repo_hashes = fetch_input_md5_hashes_from_repo(fullpaths)
+
+    # Compare hashes for each input file
+    for fullpath, repo_hash in repo_hashes.items():
+        local_hash = local_input.get(fullpath)
+        assert repo_hash == local_hash, (
+            f"MD5 hash mismatch for {fullpath}: "
+            f"repo hash: {repo_hash}, local manifest hash: {local_hash}"
         )

--- a/src/model_config_tests/config_tests/qa/test_config.py
+++ b/src/model_config_tests/config_tests/qa/test_config.py
@@ -41,7 +41,6 @@ MODEL_CONFIG_INPUTS_PRERELEASE = "/g/data/vk83/prerelease"
 PUBLISH_DATA_LOCATION = [
     "/g/data/qv56/replicas",
     "/g/data/jq44",
-    MODEL_CONFIG_INPUTS_PRERELEASE,
 ]
 
 
@@ -451,7 +450,7 @@ def read_manifest_input_hashes(control_path: Path) -> dict[str, str]:
     return local_input
 
 
-def _cache_manifest_from_input_repo(manifest_url, manifest_cache):
+def _cache_manifest_from_input_repo(manifest_url, manifest_cache, fullpath):
     """Fetch and cache the manifest file from model-config-inputs repository."""
     # Only fetch the manifest file if it is not already cached
     if manifest_url not in manifest_cache:
@@ -463,14 +462,15 @@ def _cache_manifest_from_input_repo(manifest_url, manifest_cache):
             )
 
         if response.status_code == 404:
-            raise ManifestNotFoundError(f"URL not found: {manifest_url}")
+            raise ManifestNotFoundError(f"While checking input file: {fullpath},\n URL not found at {manifest_url}")
         if response.status_code != 200:
             raise RuntimeError(
                 f"Failed to fetch manifest file from {manifest_url}: "
                 f"HTTP {response.status_code}"
             )
-        if not response.text:
-            raise RuntimeError(f"Manifest file from {manifest_url} is empty.")
+        assert response.text, (
+            f"Manifest file from {manifest_url} is empty."
+        )
 
         # YAML manifest files have headers and data, separated by `---`
         # The actual data is after the --- separator
@@ -528,7 +528,7 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
 
             # Cache the manifest file from model-config-inputs repo
             manifest_cache = _cache_manifest_from_input_repo(
-                manifest_url, manifest_cache
+                manifest_url, manifest_cache, fullpath
             )
 
             # Extract the input information for the current fullpath
@@ -537,7 +537,7 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
 
             # Extract the md5 hash for the current fullpath file
             md5hash = _extract_md5_from_repo_response(fullpath, file_info, manifest_url)
-            model_config_input[fullpath] = md5hash
+            model_config_input[fullpath] = {"md5hash": md5hash, "repo_url": manifest_url}
 
         # If no manifest was found assuming fullpath is a file, treat it as a directory
         except ManifestNotFoundError:
@@ -546,7 +546,7 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
 
             # Cache the manifest file from model-config-inputs repo
             manifest_cache = _cache_manifest_from_input_repo(
-                manifest_url, manifest_cache
+                manifest_url, manifest_cache, fullpath
             )
 
             # Extract all fullpath and md5 hashes in this manifest file
@@ -558,7 +558,7 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
                 md5hash = _extract_md5_from_repo_response(
                     complete_fullpath, file_info, manifest_url
                 )
-                model_config_input[complete_fullpath] = md5hash
+                model_config_input[complete_fullpath] = {"md5hash": md5hash, "repo_url": manifest_url}
 
         except Exception as e:
             raise RuntimeError(
@@ -599,11 +599,16 @@ def compare_input_md5_hashes(
     repo_hashes = fetch_input_md5_hashes_from_repo(fullpaths)
 
     # Compare hashes for each input file
-    for fullpath, repo_hash in repo_hashes.items():
+    for fullpath, repo_response in repo_hashes.items():
+        assert fullpath in local_input, (
+            f"Expected local input manifest to include input file:  {fullpath}"
+        )
         local_hash = local_input.get(fullpath)
+
+        repo_hash = repo_response.get("md5hash")
         assert repo_hash == local_hash, (
             f"MD5 hash mismatch for {fullpath}: "
-            f"repo hash: {repo_hash}, local manifest hash: {local_hash}"
+            f"local manifest hash: {local_hash}, repo hash: {repo_hash} from {repo_response.get('repo_url')}"
         )
 
 
@@ -626,16 +631,15 @@ def check_allowed_config_location(
             # Skip following checks
             continue
 
-        # Check if input file is in a published data project location
-        if not any(path.startswith(loc) for loc in PUBLISH_DATA_LOCATION):
-            raise RuntimeError(
-                f"Input file {path} is not in vk83 or a published data project location. "
-            )
-
         # Check if a release branch is using prerelease input files
-        if branch_type == "release" and path.startswith(MODEL_CONFIG_INPUTS_PRERELEASE):
-            raise RuntimeError(
+        if path.startswith(MODEL_CONFIG_INPUTS_PRERELEASE):
+            assert branch_type != "release", (
                 f"Input file {path} is in prerelease location, which is not allowed for release branches. "
+            )
+        else:
+            # Check if input file is in a published data project location
+            assert any(path.startswith(loc) for loc in PUBLISH_DATA_LOCATION), (
+                f"Input file {path} is not in vk83 or a published data project location: {PUBLISH_DATA_LOCATION}. "
             )
 
     return filter_fps

--- a/src/model_config_tests/config_tests/qa/test_config.py
+++ b/src/model_config_tests/config_tests/qa/test_config.py
@@ -12,6 +12,7 @@ import jsonschema
 import pytest
 import requests
 import yaml
+from yamanifest import Manifest
 
 from model_config_tests.util import get_git_branch_name
 
@@ -32,6 +33,16 @@ RELEASE_MODULE_LOCATION = "/g/data/vk83/modules"
 MODEL_CONFIG_INPUTS_RAW_URL = (
     "https://raw.githubusercontent.com/ACCESS-NRI/model-config-inputs/main"
 )
+
+# Model config input location and symlink
+MODEL_CONFIG_INPUTS_LOCATION_SYMLINK = "/g/data/vk83/experiments"
+MODEL_CONFIG_INPUTS_LOCATION = "/g/data/vk83/configurations"
+MODEL_CONFIG_INPUTS_PRERELEASE = "/g/data/vk83/prerelease"
+PUBLISH_DATA_LOCATION = [
+    "/g/data/qv56/replicas",
+    "/g/data/jq44",
+    MODEL_CONFIG_INPUTS_PRERELEASE,
+]
 
 
 class ManifestNotFoundError(Exception):
@@ -103,10 +114,10 @@ class TestRelConfig:
             + "manifest:\n    reproduce:\n        exe: True"
         )
 
-    def test_manifest_input_match_repo(self, control_path, config):
+    def test_manifest_input_match_repo(self, branch_type, control_path, config):
         """Check that input file MD5 hashes in manifests/input.yaml match
         those from model-config-inputs repository"""
-        compare_input_md5_hashes(control_path, config)
+        compare_input_md5_hashes(control_path, config, branch_type=branch_type)
 
     def test_metadata_is_enabled(self, config):
         if "metadata" in config and "enable" in config["metadata"]:
@@ -396,24 +407,17 @@ def read_input_fullpaths_from_config(config: dict[str, Any]) -> list[str]:
     """
     fullpaths = []
 
-    # Get top-level input paths
-    if "input" in config:
-        input_paths = insist_array(config["input"])
-        input_paths = [
-            p.replace("/g/data/vk83/experiments", "/g/data/vk83/configurations")
-            for p in input_paths
-        ]
-        fullpaths.extend(input_paths)
-
-    # Get submodel input paths
-    for submodel in config.get("submodels", []):
-        if "input" in submodel:
-            submodel_input_paths = insist_array(submodel["input"])
-            submodel_input_paths = [
-                p.replace("/g/data/vk83/experiments", "/g/data/vk83/configurations")
-                for p in submodel_input_paths
+    # Get top-level input paths and submodel input paths
+    for model in [config] + config.get("submodels", []):
+        if "input" in model:
+            input_paths = insist_array(model["input"])
+            input_paths = [
+                p.replace(
+                    MODEL_CONFIG_INPUTS_LOCATION_SYMLINK, MODEL_CONFIG_INPUTS_LOCATION
+                )
+                for p in input_paths
             ]
-            fullpaths.extend(submodel_input_paths)
+            fullpaths.extend(input_paths)
 
     return fullpaths
 
@@ -431,22 +435,18 @@ def read_manifest_input_hashes(control_path: Path) -> dict[str, str]:
     dict[str, str]
         Dictionary mapping fullpath to MD5 hash
     """
-
-    # This YAML manifest files have headers and data, separated by `---`
-    # The actual data is after the --- separator
-    manifest_path = control_path / "manifests" / "input.yaml"
-    with open(manifest_path) as f:
-        docs = list(yaml.safe_load_all(f))
-    data = docs[-1] if docs else {}
-
     local_input = {}
-    for _, file_info in data.items():
-        fullpath = file_info.get("fullpath")
+
+    manifest = Manifest(control_path / "manifests" / "input.yaml").load()
+
+    for filepath in manifest:
+
+        fullpath = manifest.fullpath(filepath)
         fullpath = fullpath.replace(
-            "/g/data/vk83/experiments", "/g/data/vk83/configurations"
+            MODEL_CONFIG_INPUTS_LOCATION_SYMLINK, MODEL_CONFIG_INPUTS_LOCATION
         )
-        md5hash = file_info.get("hashes", {}).get("md5", None)
-        local_input[fullpath] = md5hash
+
+        local_input[fullpath] = manifest.get(filepath, "md5")
 
     return local_input
 
@@ -455,7 +455,13 @@ def _cache_manifest_from_input_repo(manifest_url, manifest_cache):
     """Fetch and cache the manifest file from model-config-inputs repository."""
     # Only fetch the manifest file if it is not already cached
     if manifest_url not in manifest_cache:
-        response = requests.get(manifest_url)
+        try:
+            response = requests.get(manifest_url, timeout=10)
+        except requests.exceptions.Timeout:
+            raise RuntimeError(
+                f"Timeout (10s) while fetching manifest file from {manifest_url}"
+            )
+
         if response.status_code == 404:
             raise ManifestNotFoundError(f"URL not found: {manifest_url}")
         if response.status_code != 200:
@@ -562,7 +568,9 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
     return model_config_input
 
 
-def compare_input_md5_hashes(control_path: Path, config: dict[str, Any]):
+def compare_input_md5_hashes(
+    control_path: Path, config: dict[str, Any], branch_type: str = "release"
+):
     """Check that input file MD5 hashes match those in manifests/input.yaml
     and from model-config-inputs repository.
 
@@ -581,6 +589,9 @@ def compare_input_md5_hashes(control_path: Path, config: dict[str, Any]):
     # Get input fullpaths from config.yaml
     fullpaths = read_input_fullpaths_from_config(config)
 
+    # Check if all input files are in vk83 or published data project location
+    fullpaths = check_allowed_config_location(fullpaths, branch_type=branch_type)
+
     # Read local MD5 hashes from manifests/input.yaml
     local_input = read_manifest_input_hashes(control_path)
 
@@ -594,3 +605,37 @@ def compare_input_md5_hashes(control_path: Path, config: dict[str, Any]):
             f"MD5 hash mismatch for {fullpath}: "
             f"repo hash: {repo_hash}, local manifest hash: {local_hash}"
         )
+
+
+def check_allowed_config_location(
+    fullpaths: list[str], branch_type: str = "release"
+) -> list[str]:
+    """
+    Picks out input files in /g/data/vk83/configurations for furture md5 hash checking.
+    It raises a RuntimeError if:
+    - any input file is not in /g/data/vk83 or a published data project location,
+    - a release branch uses prerelease input files.
+    """
+
+    filter_fps = []
+
+    for path in fullpaths:
+        # Pick up input files in /g/data/vk83/configurations(experiments) for md5 hash checking
+        if path.startswith(MODEL_CONFIG_INPUTS_LOCATION):
+            filter_fps.append(path)
+            # Skip following checks
+            continue
+
+        # Check if input file is in a published data project location
+        if not any(path.startswith(loc) for loc in PUBLISH_DATA_LOCATION):
+            raise RuntimeError(
+                f"Input file {path} is not in vk83 or a published data project location. "
+            )
+
+        # Check if a release branch is using prerelease input files
+        if branch_type == "release" and path.startswith(MODEL_CONFIG_INPUTS_PRERELEASE):
+            raise RuntimeError(
+                f"Input file {path} is in prerelease location, which is not allowed for release branches. "
+            )
+
+    return filter_fps

--- a/src/model_config_tests/config_tests/qa/test_config.py
+++ b/src/model_config_tests/config_tests/qa/test_config.py
@@ -4,6 +4,7 @@
 """Tests for checking configs and valid metadata files"""
 
 import re
+import shutil
 import warnings
 from pathlib import Path
 from typing import Any
@@ -13,6 +14,8 @@ import pytest
 import requests
 import yaml
 from yamanifest import Manifest
+import tempfile
+import subprocess
 
 from model_config_tests.util import get_git_branch_name
 
@@ -30,8 +33,11 @@ LICENSE_URL = "https://creativecommons.org/licenses/by/4.0/legalcode.txt"
 RELEASE_MODULE_LOCATION = "/g/data/vk83/modules"
 
 # Model config inputs repository for input file MD5 verification
-MODEL_CONFIG_INPUTS_RAW_URL = (
-    "https://raw.githubusercontent.com/ACCESS-NRI/model-config-inputs/main"
+MODEL_CONFIG_INPUTS_URL = (
+    "https://github.com/ACCESS-NRI/model-config-inputs"
+)
+MODEL_CONFIG_INPUTS_CLONE_URL = (
+    "https://github.com/ACCESS-NRI/model-config-inputs.git"
 )
 
 # Model config input location and symlink
@@ -45,7 +51,7 @@ PUBLISH_DATA_LOCATION = [
 
 
 class ManifestNotFoundError(Exception):
-    """Raised when a .manifest.yaml file does not exist (HTTP 404) at the
+    """Raised when a .manifest.yaml file does not exist at the
     expected location in the model-config-inputs repository."""
 
 
@@ -113,10 +119,14 @@ class TestRelConfig:
             + "manifest:\n    reproduce:\n        exe: True"
         )
 
-    def test_manifest_input_match_repo(self, branch_type, control_path, config):
+    def test_manifest_input_match_repo(
+        self, branch_type, control_path, config, cache_input_dir
+    ):
         """Check that input file MD5 hashes in manifests/input.yaml match
         those from model-config-inputs repository"""
-        compare_input_md5_hashes(control_path, config, branch_type=branch_type)
+        compare_input_md5_hashes(
+            control_path, config, cache_input_dir, branch_type=branch_type
+        )
 
     def test_metadata_is_enabled(self, config):
         if "metadata" in config and "enable" in config["metadata"]:
@@ -450,132 +460,140 @@ def read_manifest_input_hashes(control_path: Path) -> dict[str, str]:
     return local_input
 
 
-def _cache_manifest_from_input_repo(manifest_url, manifest_cache, fullpath):
-    """Fetch and cache the manifest file from model-config-inputs repository."""
-    # Only fetch the manifest file if it is not already cached
-    if manifest_url not in manifest_cache:
-        try:
-            response = requests.get(manifest_url, timeout=10)
-        except requests.exceptions.Timeout:
-            raise RuntimeError(
-                f"Timeout (10s) while fetching manifest file from {manifest_url}"
-            )
-
-        if response.status_code == 404:
-            raise ManifestNotFoundError(
-                f"While checking input file: {fullpath},\n URL not found at {manifest_url}"
-            )
-        if response.status_code != 200:
-            raise RuntimeError(
-                f"Failed to fetch manifest file from {manifest_url}: "
-                f"HTTP {response.status_code}"
-            )
-        assert response.text, f"Manifest file from {manifest_url} is empty."
-
-        # YAML manifest files have headers and data, separated by `---`
-        # The actual data is after the --- separator
-        docs = list(yaml.safe_load_all(response.text))
-        manifest_cache[manifest_url] = docs[-1]
-
-    return manifest_cache
-
-
-def _extract_md5_from_repo_response(fullpath, file_info, manifest_url):
-    """Extract the md5 hash for a given fullpath from the manifest file fetched from the model-config-inputs repository."""
-    # Check if the fullpath in the input repo matches the fullpath from config.yaml
-    if fullpath == file_info.get("fullpath"):
-        return file_info.get("hashes", {}).get("md5", None)
-
-    else:
-        # If fullpath not matching, raise an error
-        raise RuntimeError(
-            f"Fullpath in config.yaml \"{fullpath}\" does not match the one \"{file_info.get('fullpath')}\" in model-config-inputs repo {manifest_url}."
+def _cache_input_repo() -> Path:
+    """Fetch and cache the entire model-config-inputs repository."""
+    cache_input_dir = Path(tempfile.mkdtemp())
+    try:
+        # Clone the model-config-inputs repository into a temporary directory
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--branch",
+                "main",
+                "--depth",
+                "1",
+                MODEL_CONFIG_INPUTS_CLONE_URL,
+                cache_input_dir,
+            ],
+            check=True,
+            timeout=100,
         )
 
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        shutil.rmtree(cache_input_dir, ignore_errors=True)
+        raise RuntimeError(
+            f"Failed to clone model-config-inputs repository from {MODEL_CONFIG_INPUTS_CLONE_URL}: {e}"
+        ) from e
+    
+    return cache_input_dir
 
-def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
-    """Fetch MD5 hashes for input files from model-config-inputs repository.
 
-    The repo contains .manifest.yaml files that store MD5 hashes for input files.
-    Path mapping: /g/data/vk83/configurations/inputs/access-om2/subdir/file.nc
-    maps to: access-om2/subdir/.manifest.yaml
+@pytest.fixture(scope="session")
+def cache_input_dir():
+    """Clone the model-config-inputs repository once per test session and
+    clean up the temporary clone once all tests using it have finished."""
+    cache_dir = _cache_input_repo()
+    yield cache_dir
+    shutil.rmtree(cache_dir, ignore_errors=True)
+
+
+def match_file_name_in_repo(file_name: str,
+    data: Manifest,
+    repo_manifest_path: Path,
+) -> str:
+    """Match a file name to its key in the manifest.
+    The model-config-inputs repository may store file names with or without
+    a leading ``./`` (e.g. ``basin_mask.nc`` or ``./basin_mask.nc``)."""
+    if file_name in data:
+        manifest_file_name = file_name
+    elif f"./{file_name}" in data:
+        manifest_file_name = f"./{file_name}"
+    else:
+        raise ValueError(
+            f"Neither file name {file_name} and ./{file_name} not found in manifest {MODEL_CONFIG_INPUTS_URL}/tree/main/{repo_manifest_path}. "
+        )
+
+    return manifest_file_name
+
+def extract_input_md5_hashes_from_repo(fullpaths: list[str], cache_input_dir: Path) -> dict[str, dict[str, str]]:
+    """Extract MD5 hashes for input files from local-cloned model-config-inputs repository.
 
     Parameters
     ----------
     fullpaths : list[str]
-        List of fullpaths to input files
+        List of fullpaths to input files from config.yaml
+    cache_input_dir : Path
+        Path to the cached model-config-inputs repository
 
     Returns
     -------
-    dict[str, str]
-        Dictionary mapping fullpath to MD5 hash from repo
+    dict[str, dict[str, str]]
+        Dictionary mapping fullpath to {MD5 hash, repo URL} from repo
     """
     model_config_input = {}
-    manifest_cache = (
-        {}
-    )  # {manifest_url1: manifest_data1, manifest_url2: manifest_data2, ...}, cached from input repo
 
     for fullpath in fullpaths:
-        # Try treating fullpath as a file first: the manifest lives in its
-        # parent directory. If no manifest is found there (404), fall back to
-        # treating fullpath as a directory where manifest lives.
-        try:
-            # Build the manifest file url on the model-config-inputs repo
-            path = fullpath.split("/inputs/")[-1]
-            manifest_url = (
-                f"{MODEL_CONFIG_INPUTS_RAW_URL}/{Path(path).parent}/.manifest.yaml"
+        path = cache_input_dir / fullpath.split("/inputs/")[-1]
+
+        # If fullpath is a file, manifest_path should exist
+        manifest_path = path.parent / ".manifest.yaml"
+        if manifest_path.is_file():
+            repo_manifest_path = manifest_path.relative_to(cache_input_dir) # For error message
+
+            # Load the manifest and extract fullpath for this input file
+            data = Manifest(manifest_path).load()
+
+            # Get the file name matching the input repo
+            manifest_file_name = match_file_name_in_repo(path.name, data, repo_manifest_path)
+
+            # Check if the fullpath in the input repo matches the fullpath from config.yaml
+            repo_fullpath = data.fullpath(manifest_file_name)
+            assert fullpath == repo_fullpath, (
+                f"Fullpath in config.yaml \"{fullpath}\" does not match the one \"{repo_fullpath}\" in model-config-inputs repo"
+                f"in {MODEL_CONFIG_INPUTS_URL}/tree/main/{repo_manifest_path}."
             )
 
-            # Cache the manifest file from model-config-inputs repo
-            manifest_cache = _cache_manifest_from_input_repo(
-                manifest_url, manifest_cache, fullpath
-            )
+            model_config_input[fullpath] = {"md5hash": data.get(manifest_file_name, "md5"),
+                                            "repo_url": f"{MODEL_CONFIG_INPUTS_URL}/tree/main/{repo_manifest_path}"}
 
-            # Extract the input information for the current fullpath
-            file_name = Path(fullpath).name
-            file_info = manifest_cache[manifest_url].get(file_name, {})
+        else:
+            # Assume that fullpath is a directory
+            # Look for all .manifest.yaml files in the directory and its subdirectories
+            manifest_paths = list(path.rglob(".manifest.yaml"))
 
-            # Extract the md5 hash for the current fullpath file
-            md5hash = _extract_md5_from_repo_response(fullpath, file_info, manifest_url)
-            model_config_input[fullpath] = {
-                "md5hash": md5hash,
-                "repo_url": manifest_url,
-            }
-
-        # If no manifest was found assuming fullpath is a file, treat it as a directory
-        except ManifestNotFoundError:
-            path = fullpath.split("/inputs/")[-1]
-            manifest_url = f"{MODEL_CONFIG_INPUTS_RAW_URL}/{path}/.manifest.yaml"
-
-            # Cache the manifest file from model-config-inputs repo
-            manifest_cache = _cache_manifest_from_input_repo(
-                manifest_url, manifest_cache, fullpath
-            )
-
-            # Extract all fullpath and md5 hashes in this manifest file
-            for file_name, file_info in manifest_cache[manifest_url].items():
-                # Build the complete fullpath for each file in the directory
-                complete_fullpath = f"{fullpath}/{file_name}"
-
-                # Extract the md5 hash for each file in the directory
-                md5hash = _extract_md5_from_repo_response(
-                    complete_fullpath, file_info, manifest_url
+            # Raise an error if still no manifest files are found
+            if not manifest_paths: 
+                raise ManifestNotFoundError(
+                    f"No manifest files found for input file/directory \"{fullpath}\"."
+                    f"Searched recursively in model-config-inputs repo at {MODEL_CONFIG_INPUTS_URL}/tree/main/{path.relative_to(cache_input_dir)}."
+                    f"Expected to find at least one .manifest.yaml file."
                 )
-                model_config_input[complete_fullpath] = {
-                    "md5hash": md5hash,
-                    "repo_url": manifest_url,
-                }
 
-        except Exception as e:
-            raise RuntimeError(
-                f"Failed to fetch MD5 hash for {fullpath} from model-config-inputs repo: {e}"
-            )
+            # Load each manifest file 
+            for manifest_path in manifest_paths:
+                data = Manifest(manifest_path).load()
+                repo_manifest_path = manifest_path.relative_to(cache_input_dir)
 
+                # Extract all files' fullpath and md5hash
+                for file in data:
+                    if file == ".manifest.yaml":
+                        # Skip .manifest.yaml
+                        continue
+
+                    repo_fullpath = data.fullpath(file)
+                    md5hash = data.get(file, "md5")
+                    model_config_input[repo_fullpath] = {"md5hash": md5hash,
+                                                        "repo_url": f"{MODEL_CONFIG_INPUTS_URL}/tree/main/{repo_manifest_path}"}
+                        
     return model_config_input
 
 
 def compare_input_md5_hashes(
-    control_path: Path, config: dict[str, Any], branch_type: str = "release"
+    control_path: Path,
+    config: dict[str, Any],
+    cache_input_dir: Path,
+    branch_type: str = "release",
 ):
     """Check that input file MD5 hashes match those in manifests/input.yaml
     and from model-config-inputs repository.
@@ -586,6 +604,8 @@ def compare_input_md5_hashes(
         Path to the model configuration directory
     config : Dict[str, Any]
         The contents of the config.yaml file
+    cache_input_dir : Path
+        Path to the cached model-config-inputs repository
 
     Raises
     ------
@@ -602,7 +622,10 @@ def compare_input_md5_hashes(
     local_input = read_manifest_input_hashes(control_path)
 
     # Fetch MD5 hashes from model-config-inputs repo
-    repo_hashes = fetch_input_md5_hashes_from_repo(fullpaths)
+    try:
+        repo_hashes = extract_input_md5_hashes_from_repo(fullpaths, cache_input_dir)
+    except RuntimeError as e:
+        raise RuntimeError(f"Error extracting MD5 hashes from model-config-inputs repo: {e}")
 
     # Compare hashes for each input file
     for fullpath, repo_response in repo_hashes.items():

--- a/src/model_config_tests/config_tests/qa/test_config.py
+++ b/src/model_config_tests/config_tests/qa/test_config.py
@@ -5,6 +5,8 @@
 
 import re
 import shutil
+import subprocess
+import tempfile
 import warnings
 from pathlib import Path
 from typing import Any
@@ -14,8 +16,6 @@ import pytest
 import requests
 import yaml
 from yamanifest import Manifest
-import tempfile
-import subprocess
 
 from model_config_tests.util import get_git_branch_name
 
@@ -33,12 +33,8 @@ LICENSE_URL = "https://creativecommons.org/licenses/by/4.0/legalcode.txt"
 RELEASE_MODULE_LOCATION = "/g/data/vk83/modules"
 
 # Model config inputs repository for input file MD5 verification
-MODEL_CONFIG_INPUTS_URL = (
-    "https://github.com/ACCESS-NRI/model-config-inputs"
-)
-MODEL_CONFIG_INPUTS_CLONE_URL = (
-    "https://github.com/ACCESS-NRI/model-config-inputs.git"
-)
+MODEL_CONFIG_INPUTS_URL = "https://github.com/ACCESS-NRI/model-config-inputs"
+MODEL_CONFIG_INPUTS_CLONE_URL = "https://github.com/ACCESS-NRI/model-config-inputs.git"
 
 # Model config input location and symlink
 MODEL_CONFIG_INPUTS_LOCATION_SYMLINK = "/g/data/vk83/experiments"
@@ -485,7 +481,7 @@ def _cache_input_repo() -> Path:
         raise RuntimeError(
             f"Failed to clone model-config-inputs repository from {MODEL_CONFIG_INPUTS_CLONE_URL}: {e}"
         ) from e
-    
+
     return cache_input_dir
 
 
@@ -498,7 +494,8 @@ def cache_input_dir():
     shutil.rmtree(cache_dir, ignore_errors=True)
 
 
-def match_file_name_in_repo(file_name: str,
+def match_file_name_in_repo(
+    file_name: str,
     data: Manifest,
     repo_manifest_path: Path,
 ) -> str:
@@ -516,7 +513,10 @@ def match_file_name_in_repo(file_name: str,
 
     return manifest_file_name
 
-def extract_input_md5_hashes_from_repo(fullpaths: list[str], cache_input_dir: Path) -> dict[str, dict[str, str]]:
+
+def extract_input_md5_hashes_from_repo(
+    fullpaths: list[str], cache_input_dir: Path
+) -> dict[str, dict[str, str]]:
     """Extract MD5 hashes for input files from local-cloned model-config-inputs repository.
 
     Parameters
@@ -539,23 +539,29 @@ def extract_input_md5_hashes_from_repo(fullpaths: list[str], cache_input_dir: Pa
         # If fullpath is a file, manifest_path should exist
         manifest_path = path.parent / ".manifest.yaml"
         if manifest_path.is_file():
-            repo_manifest_path = manifest_path.relative_to(cache_input_dir) # For error message
+            repo_manifest_path = manifest_path.relative_to(
+                cache_input_dir
+            )  # For error message
 
             # Load the manifest and extract fullpath for this input file
             data = Manifest(manifest_path).load()
 
             # Get the file name matching the input repo
-            manifest_file_name = match_file_name_in_repo(path.name, data, repo_manifest_path)
+            manifest_file_name = match_file_name_in_repo(
+                path.name, data, repo_manifest_path
+            )
 
             # Check if the fullpath in the input repo matches the fullpath from config.yaml
             repo_fullpath = data.fullpath(manifest_file_name)
             assert fullpath == repo_fullpath, (
-                f"Fullpath in config.yaml \"{fullpath}\" does not match the one \"{repo_fullpath}\" in model-config-inputs repo"
+                f'Fullpath in config.yaml "{fullpath}" does not match the one "{repo_fullpath}" in model-config-inputs repo'
                 f"in {MODEL_CONFIG_INPUTS_URL}/tree/main/{repo_manifest_path}."
             )
 
-            model_config_input[fullpath] = {"md5hash": data.get(manifest_file_name, "md5"),
-                                            "repo_url": f"{MODEL_CONFIG_INPUTS_URL}/tree/main/{repo_manifest_path}"}
+            model_config_input[fullpath] = {
+                "md5hash": data.get(manifest_file_name, "md5"),
+                "repo_url": f"{MODEL_CONFIG_INPUTS_URL}/tree/main/{repo_manifest_path}",
+            }
 
         else:
             # Assume that fullpath is a directory
@@ -563,14 +569,14 @@ def extract_input_md5_hashes_from_repo(fullpaths: list[str], cache_input_dir: Pa
             manifest_paths = list(path.rglob(".manifest.yaml"))
 
             # Raise an error if still no manifest files are found
-            if not manifest_paths: 
+            if not manifest_paths:
                 raise ManifestNotFoundError(
-                    f"No manifest files found for input file/directory \"{fullpath}\"."
+                    f'No manifest files found for input file/directory "{fullpath}".'
                     f"Searched recursively in model-config-inputs repo at {MODEL_CONFIG_INPUTS_URL}/tree/main/{path.relative_to(cache_input_dir)}."
                     f"Expected to find at least one .manifest.yaml file."
                 )
 
-            # Load each manifest file 
+            # Load each manifest file
             for manifest_path in manifest_paths:
                 data = Manifest(manifest_path).load()
                 repo_manifest_path = manifest_path.relative_to(cache_input_dir)
@@ -583,9 +589,11 @@ def extract_input_md5_hashes_from_repo(fullpaths: list[str], cache_input_dir: Pa
 
                     repo_fullpath = data.fullpath(file)
                     md5hash = data.get(file, "md5")
-                    model_config_input[repo_fullpath] = {"md5hash": md5hash,
-                                                        "repo_url": f"{MODEL_CONFIG_INPUTS_URL}/tree/main/{repo_manifest_path}"}
-                        
+                    model_config_input[repo_fullpath] = {
+                        "md5hash": md5hash,
+                        "repo_url": f"{MODEL_CONFIG_INPUTS_URL}/tree/main/{repo_manifest_path}",
+                    }
+
     return model_config_input
 
 
@@ -625,7 +633,9 @@ def compare_input_md5_hashes(
     try:
         repo_hashes = extract_input_md5_hashes_from_repo(fullpaths, cache_input_dir)
     except RuntimeError as e:
-        raise RuntimeError(f"Error extracting MD5 hashes from model-config-inputs repo: {e}")
+        raise RuntimeError(
+            f"Error extracting MD5 hashes from model-config-inputs repo: {e}"
+        )
 
     # Compare hashes for each input file
     for fullpath, repo_response in repo_hashes.items():

--- a/src/model_config_tests/config_tests/qa/test_config.py
+++ b/src/model_config_tests/config_tests/qa/test_config.py
@@ -447,19 +447,23 @@ def read_manifest_input_hashes(control_path: Path) -> dict[str, str]:
     return local_input
 
 
-def cache_manifest_from_input_repo(manifest_url, manifest_cache):
+def _cache_manifest_from_input_repo(manifest_url, manifest_cache):
     """Fetch and cache the manifest file from model-config-inputs repository."""
     # Only fetch the manifest file if it is not already cached
     if manifest_url not in manifest_cache:
         response = requests.get(manifest_url)
-        assert response.status_code == 200, (
-            f"Failed to fetch manifest file from {manifest_url}: "
-            f"HTTP {response.status_code}"
-        )
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Failed to fetch manifest file from {manifest_url}: "
+                f"HTTP {response.status_code}"
+            )
+        if not response.text:
+            raise RuntimeError(f"Manifest file from {manifest_url} is empty.")
+
         # YAML manifest files have headers and data, separated by `---`
         # The actual data is after the --- separator
         docs = list(yaml.safe_load_all(response.text))
-        manifest_cache[manifest_url] = docs[-1] if docs else {}
+        manifest_cache[manifest_url] = docs[-1]
 
     return manifest_cache
 
@@ -509,7 +513,7 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
             )
 
             # Cache the manifest file from model-config-inputs repo
-            manifest_cache = cache_manifest_from_input_repo(
+            manifest_cache = _cache_manifest_from_input_repo(
                 manifest_url, manifest_cache
             )
 
@@ -528,7 +532,7 @@ def fetch_input_md5_hashes_from_repo(fullpaths: list[str]) -> dict[str, str]:
             manifest_url = f"{MODEL_CONFIG_INPUTS_RAW_URL}/{path}/.manifest.yaml"
 
             # Cache the manifest file from model-config-inputs repo
-            manifest_cache = cache_manifest_from_input_repo(
+            manifest_cache = _cache_manifest_from_input_repo(
                 manifest_url, manifest_cache
             )
 

--- a/tests/config_tests/qa/test_test_config.py
+++ b/tests/config_tests/qa/test_test_config.py
@@ -1,5 +1,4 @@
 import shlex
-import shutil
 import subprocess
 import warnings
 from pathlib import Path
@@ -14,8 +13,6 @@ from model_config_tests.config_tests.qa.test_config import (
     MODEL_CONFIG_INPUTS_LOCATION,
     MODEL_CONFIG_INPUTS_PRERELEASE,
     PUBLISH_DATA_LOCATION,
-    _cache_input_repo,
-    cache_input_dir,
     check_allowed_config_location,
     compare_input_md5_hashes,
     extract_input_md5_hashes_from_repo,
@@ -30,7 +27,6 @@ from tests.resources.expected_md5hash import (
     expected_fullpaths,
     expected_hashes_from_repo,
     expected_local_hashes,
-    mock_input_response,
 )
 
 
@@ -184,16 +180,15 @@ def test_read_input_fullpaths_from_config():
     assert fullpaths == expected_fullpaths
 
 
-def test_extract_input_md5_hashes_from_repo():
+def test_extract_input_md5_hashes_from_repo(cache_input_dir):
     """Test that the extract_input_md5_hashes_from_repo function loads the
     correct md5 hashes from the local-cloned model-config-inputs repository."""
-    cache_input_dir = _cache_input_repo()
-    fetch_result = extract_input_md5_hashes_from_repo(expected_fullpaths, cache_input_dir)
+    fetch_result = extract_input_md5_hashes_from_repo(
+        expected_fullpaths, cache_input_dir
+    )
     assert expected_hashes_from_repo == {
         fullpath: info["md5hash"] for fullpath, info in fetch_result.items()
     }
-    shutil.rmtree(cache_input_dir, ignore_errors=True)
-
 
 
 def test_read_manifest_input_hashes():

--- a/tests/config_tests/qa/test_test_config.py
+++ b/tests/config_tests/qa/test_test_config.py
@@ -23,6 +23,7 @@ from tests.resources.expected_md5hash import (
     expected_fullpaths,
     expected_hashes_from_repo,
     expected_local_hashes,
+    mock_input_response,
 )
 
 
@@ -177,11 +178,21 @@ def test_read_input_fullpaths_from_config():
 
 
 def test_fetch_input_md5_hashes_from_repo():
-    """Test that the fetch_input_md5_hashes_from_repo function fetches
+    """Test that the fetch_input_md5_hashes_from_repo function loads the
     correct md5 hashes from model-config-inputs repository."""
-    assert expected_hashes_from_repo == fetch_input_md5_hashes_from_repo(
-        expected_fullpaths
-    )
+
+    # Mock requests.get to return a predefined manifest response, instead of actually
+    # fetching it from the model-config-inputs repository.
+    def mock_requests_get(manifest_url):
+        response = Mock()
+        response.status_code = 200
+        response.text = mock_input_response[manifest_url]
+        return response
+
+    with patch("requests.get", side_effect=mock_requests_get):
+        assert expected_hashes_from_repo == fetch_input_md5_hashes_from_repo(
+            expected_fullpaths
+        )
 
 
 def test_read_manifest_input_hashes():

--- a/tests/config_tests/qa/test_test_config.py
+++ b/tests/config_tests/qa/test_test_config.py
@@ -1,4 +1,5 @@
 import shlex
+import shutil
 import subprocess
 import warnings
 from pathlib import Path
@@ -13,9 +14,11 @@ from model_config_tests.config_tests.qa.test_config import (
     MODEL_CONFIG_INPUTS_LOCATION,
     MODEL_CONFIG_INPUTS_PRERELEASE,
     PUBLISH_DATA_LOCATION,
+    _cache_input_repo,
+    cache_input_dir,
     check_allowed_config_location,
     compare_input_md5_hashes,
-    fetch_input_md5_hashes_from_repo,
+    extract_input_md5_hashes_from_repo,
     get_spack_location_file,
     read_input_fullpaths_from_config,
     read_manifest_input_hashes,
@@ -181,41 +184,16 @@ def test_read_input_fullpaths_from_config():
     assert fullpaths == expected_fullpaths
 
 
-def test_fetch_input_md5_hashes_from_repo():
-    """Test that the fetch_input_md5_hashes_from_repo function loads the
-    correct md5 hashes from model-config-inputs repository."""
+def test_extract_input_md5_hashes_from_repo():
+    """Test that the extract_input_md5_hashes_from_repo function loads the
+    correct md5 hashes from the local-cloned model-config-inputs repository."""
+    cache_input_dir = _cache_input_repo()
+    fetch_result = extract_input_md5_hashes_from_repo(expected_fullpaths, cache_input_dir)
+    assert expected_hashes_from_repo == {
+        fullpath: info["md5hash"] for fullpath, info in fetch_result.items()
+    }
+    shutil.rmtree(cache_input_dir, ignore_errors=True)
 
-    # Mock requests.get to return a predefined manifest response.
-    # URLs not present in mock_input_response simulate a missing manifest file (HTTP 404), so that
-    # fetch_input_md5_hashes_from_repo falls back to treating the path as a directory.
-    def mock_requests_get(manifest_url, timeout):
-        response = Mock()
-        if manifest_url in mock_input_response:
-            response.status_code = 200
-            response.text = mock_input_response[manifest_url]
-        else:
-            response.status_code = 404
-        return response
-
-    with patch("requests.get", side_effect=mock_requests_get):
-        fetch_result = fetch_input_md5_hashes_from_repo(expected_fullpaths)
-        assert expected_hashes_from_repo == {
-            fullpath: info["md5hash"] for fullpath, info in fetch_result.items()
-        }
-
-
-def test_fetch_input_md5_hashes_from_repo_invalid():
-    """Test that the fetch_input_md5_hashes_from_repo() raises an error with an invalid input file."""
-
-    # Mock requests.get to return a 404 for all URLs, simulating missing manifests
-    def mock_requests_get(manifest_url, timeout):
-        response = Mock()
-        response.status_code = 502
-        return response
-
-    with patch("requests.get", side_effect=mock_requests_get):
-        with pytest.raises(RuntimeError, match="Failed to fetch MD5 hash"):
-            fetch_input_md5_hashes_from_repo(expected_fullpaths)
 
 
 def test_read_manifest_input_hashes():
@@ -230,7 +208,7 @@ def test_read_manifest_input_hashes():
     assert read_manifest_input_hashes(control_path) == expected_local_hashes
 
 
-def test_compare_input_md5_hashes():
+def test_compare_input_md5_hashes(cache_input_dir):
     """Test that the compare_input_md5_hashes function correctly compares
     MD5 hashes between local manifests and the model-config-inputs repository."""
     control_path = (
@@ -240,7 +218,7 @@ def test_compare_input_md5_hashes():
     with open(config_path) as f:
         config = yaml.safe_load(f)
 
-    compare_input_md5_hashes(control_path, config)
+    compare_input_md5_hashes(control_path, config, cache_input_dir)
 
 
 @pytest.mark.parametrize(

--- a/tests/config_tests/qa/test_test_config.py
+++ b/tests/config_tests/qa/test_test_config.py
@@ -181,18 +181,36 @@ def test_fetch_input_md5_hashes_from_repo():
     """Test that the fetch_input_md5_hashes_from_repo function loads the
     correct md5 hashes from model-config-inputs repository."""
 
-    # Mock requests.get to return a predefined manifest response, instead of actually
-    # fetching it from the model-config-inputs repository.
+    # Mock requests.get to return a predefined manifest response.
+    # URLs not present in mock_input_response simulate a missing manifest file (HTTP 404), so that
+    # fetch_input_md5_hashes_from_repo falls back to treating the path as a directory.
     def mock_requests_get(manifest_url):
         response = Mock()
-        response.status_code = 200
-        response.text = mock_input_response[manifest_url]
+        if manifest_url in mock_input_response:
+            response.status_code = 200
+            response.text = mock_input_response[manifest_url]
+        else:
+            response.status_code = 404
         return response
 
     with patch("requests.get", side_effect=mock_requests_get):
         assert expected_hashes_from_repo == fetch_input_md5_hashes_from_repo(
             expected_fullpaths
         )
+
+
+def test_fetch_input_md5_hashes_from_repo_invalid():
+    """Test that the fetch_input_md5_hashes_from_repo() raises an error with an invalid input file."""
+
+    # Mock requests.get to return a 404 for all URLs, simulating missing manifests
+    def mock_requests_get(manifest_url):
+        response = Mock()
+        response.status_code = 502
+        return response
+
+    with patch("requests.get", side_effect=mock_requests_get):
+        with pytest.raises(RuntimeError, match="Failed to fetch MD5 hash"):
+            fetch_input_md5_hashes_from_repo(expected_fullpaths)
 
 
 def test_read_manifest_input_hashes():

--- a/tests/config_tests/qa/test_test_config.py
+++ b/tests/config_tests/qa/test_test_config.py
@@ -1,4 +1,5 @@
 import shlex
+import shutil
 import subprocess
 import warnings
 from pathlib import Path
@@ -13,6 +14,7 @@ from model_config_tests.config_tests.qa.test_config import (
     MODEL_CONFIG_INPUTS_LOCATION,
     MODEL_CONFIG_INPUTS_PRERELEASE,
     PUBLISH_DATA_LOCATION,
+    _cache_input_repo,
     check_allowed_config_location,
     compare_input_md5_hashes,
     extract_input_md5_hashes_from_repo,
@@ -22,12 +24,21 @@ from model_config_tests.config_tests.qa.test_config import (
 )
 from model_config_tests.config_tests.qa.test_config import TestConfig as ConfigValidator
 
-# Import test fixtures
+# Import test resource
 from tests.resources.expected_md5hash import (
     expected_fullpaths,
     expected_hashes_from_repo,
     expected_local_hashes,
 )
+
+
+@pytest.fixture(scope="session")
+def cache_input_dir():
+    """Clone the model-config-inputs repository once per test session and
+    clean up the temporary clone once all tests using it have finished."""
+    cache_dir = _cache_input_repo()
+    yield cache_dir
+    shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 def test_test_config_access_om2(tmp_path, isolated_config):

--- a/tests/config_tests/qa/test_test_config.py
+++ b/tests/config_tests/qa/test_test_config.py
@@ -1,6 +1,8 @@
 import shlex
 import subprocess
 import warnings
+import yaml
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
@@ -9,6 +11,11 @@ import pytest
 warnings.filterwarnings("ignore", category=pytest.PytestUnknownMarkWarning)
 from model_config_tests.config_tests.qa.test_config import TestConfig as ConfigValidator
 from model_config_tests.config_tests.qa.test_config import get_spack_location_file
+from model_config_tests.config_tests.qa.test_config import read_input_fullpaths_from_config, fetch_input_md5_hashes_from_repo
+from model_config_tests.config_tests.qa.test_config import read_manifest_input_hashes, compare_input_md5_hashes
+
+# Import test fixtures
+from tests.resources.expected_md5hash import *
 
 
 def test_test_config_access_om2(tmp_path, isolated_config):
@@ -143,3 +150,43 @@ def test_test_sync_path_not_exists(checker):
         AssertionError, match="Sync path should not exist since base_path is preferred"
     ):
         checker.test_sync_path_not_exists(config_fail2)
+
+
+def test_read_input_fullpaths_from_config():
+    """Test that the get_input_fullpaths_from_config function properly extracts input full paths from config."""
+    # Load example config file
+    control_path = Path(__file__).parent.parent.parent / "resources" / "example_control_dir"
+    with open(control_path / "config.yaml", "r") as f:
+        config = yaml.safe_load(f)
+    
+    # Extract fullpaths using the function being tested
+    fullpaths = read_input_fullpaths_from_config(config)
+    
+    # Assert that the extracted fullpaths match the expected list
+    assert fullpaths == expected_fullpaths
+
+
+def test_fetch_input_md5_hashes_from_repo():
+    """Test that the fetch_input_md5_hashes_from_repo function fetches
+    correct md5 hashes from model-config-inputs repository."""
+    assert expected_hashes_from_repo == fetch_input_md5_hashes_from_repo(expected_fullpaths)
+
+def test_read_manifest_input_hashes():
+    """Test that the read_manifest_input_hashes function reads
+    correct md5 hashes from the manifest file."""
+    # Load example manifest file
+    control_path = Path(__file__).parent.parent.parent / "resources" / "example_control_dir"
+
+    # Assert that the extracted md5 hashes match the expected dictionary
+    assert read_manifest_input_hashes(control_path) == expected_local_hashes
+
+
+def test_compare_input_md5_hashes():
+    """Test that the compare_input_md5_hashes function correctly compares
+    MD5 hashes between local manifests and the model-config-inputs repository."""
+    control_path = Path(__file__).parent.parent.parent / "resources" / "example_control_dir"
+    config_path = control_path / "config.yaml"
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f)
+
+    compare_input_md5_hashes(control_path, config)

--- a/tests/config_tests/qa/test_test_config.py
+++ b/tests/config_tests/qa/test_test_config.py
@@ -1,21 +1,29 @@
 import shlex
 import subprocess
 import warnings
-import yaml
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+import yaml
 
 # Disable specific warnings from test_config tests
 warnings.filterwarnings("ignore", category=pytest.PytestUnknownMarkWarning)
 from model_config_tests.config_tests.qa.test_config import TestConfig as ConfigValidator
-from model_config_tests.config_tests.qa.test_config import get_spack_location_file
-from model_config_tests.config_tests.qa.test_config import read_input_fullpaths_from_config, fetch_input_md5_hashes_from_repo
-from model_config_tests.config_tests.qa.test_config import read_manifest_input_hashes, compare_input_md5_hashes
+from model_config_tests.config_tests.qa.test_config import (
+    compare_input_md5_hashes,
+    fetch_input_md5_hashes_from_repo,
+    get_spack_location_file,
+    read_input_fullpaths_from_config,
+    read_manifest_input_hashes,
+)
 
 # Import test fixtures
-from tests.resources.expected_md5hash import *
+from tests.resources.expected_md5hash import (
+    expected_fullpaths,
+    expected_hashes_from_repo,
+    expected_local_hashes,
+)
 
 
 def test_test_config_access_om2(tmp_path, isolated_config):
@@ -155,13 +163,15 @@ def test_test_sync_path_not_exists(checker):
 def test_read_input_fullpaths_from_config():
     """Test that the get_input_fullpaths_from_config function properly extracts input full paths from config."""
     # Load example config file
-    control_path = Path(__file__).parent.parent.parent / "resources" / "example_control_dir"
-    with open(control_path / "config.yaml", "r") as f:
+    control_path = (
+        Path(__file__).parent.parent.parent / "resources" / "example_control_dir"
+    )
+    with open(control_path / "config.yaml") as f:
         config = yaml.safe_load(f)
-    
+
     # Extract fullpaths using the function being tested
     fullpaths = read_input_fullpaths_from_config(config)
-    
+
     # Assert that the extracted fullpaths match the expected list
     assert fullpaths == expected_fullpaths
 
@@ -169,13 +179,18 @@ def test_read_input_fullpaths_from_config():
 def test_fetch_input_md5_hashes_from_repo():
     """Test that the fetch_input_md5_hashes_from_repo function fetches
     correct md5 hashes from model-config-inputs repository."""
-    assert expected_hashes_from_repo == fetch_input_md5_hashes_from_repo(expected_fullpaths)
+    assert expected_hashes_from_repo == fetch_input_md5_hashes_from_repo(
+        expected_fullpaths
+    )
+
 
 def test_read_manifest_input_hashes():
     """Test that the read_manifest_input_hashes function reads
     correct md5 hashes from the manifest file."""
     # Load example manifest file
-    control_path = Path(__file__).parent.parent.parent / "resources" / "example_control_dir"
+    control_path = (
+        Path(__file__).parent.parent.parent / "resources" / "example_control_dir"
+    )
 
     # Assert that the extracted md5 hashes match the expected dictionary
     assert read_manifest_input_hashes(control_path) == expected_local_hashes
@@ -184,9 +199,11 @@ def test_read_manifest_input_hashes():
 def test_compare_input_md5_hashes():
     """Test that the compare_input_md5_hashes function correctly compares
     MD5 hashes between local manifests and the model-config-inputs repository."""
-    control_path = Path(__file__).parent.parent.parent / "resources" / "example_control_dir"
+    control_path = (
+        Path(__file__).parent.parent.parent / "resources" / "example_control_dir"
+    )
     config_path = control_path / "config.yaml"
-    with open(config_path, "r") as f:
+    with open(config_path) as f:
         config = yaml.safe_load(f)
 
     compare_input_md5_hashes(control_path, config)

--- a/tests/config_tests/qa/test_test_config.py
+++ b/tests/config_tests/qa/test_test_config.py
@@ -9,14 +9,18 @@ import yaml
 
 # Disable specific warnings from test_config tests
 warnings.filterwarnings("ignore", category=pytest.PytestUnknownMarkWarning)
-from model_config_tests.config_tests.qa.test_config import TestConfig as ConfigValidator
 from model_config_tests.config_tests.qa.test_config import (
+    MODEL_CONFIG_INPUTS_LOCATION,
+    MODEL_CONFIG_INPUTS_PRERELEASE,
+    PUBLISH_DATA_LOCATION,
+    check_allowed_config_location,
     compare_input_md5_hashes,
     fetch_input_md5_hashes_from_repo,
     get_spack_location_file,
     read_input_fullpaths_from_config,
     read_manifest_input_hashes,
 )
+from model_config_tests.config_tests.qa.test_config import TestConfig as ConfigValidator
 
 # Import test fixtures
 from tests.resources.expected_md5hash import (
@@ -184,7 +188,7 @@ def test_fetch_input_md5_hashes_from_repo():
     # Mock requests.get to return a predefined manifest response.
     # URLs not present in mock_input_response simulate a missing manifest file (HTTP 404), so that
     # fetch_input_md5_hashes_from_repo falls back to treating the path as a directory.
-    def mock_requests_get(manifest_url):
+    def mock_requests_get(manifest_url, timeout):
         response = Mock()
         if manifest_url in mock_input_response:
             response.status_code = 200
@@ -203,7 +207,7 @@ def test_fetch_input_md5_hashes_from_repo_invalid():
     """Test that the fetch_input_md5_hashes_from_repo() raises an error with an invalid input file."""
 
     # Mock requests.get to return a 404 for all URLs, simulating missing manifests
-    def mock_requests_get(manifest_url):
+    def mock_requests_get(manifest_url, timeout):
         response = Mock()
         response.status_code = 502
         return response
@@ -236,3 +240,52 @@ def test_compare_input_md5_hashes():
         config = yaml.safe_load(f)
 
     compare_input_md5_hashes(control_path, config)
+
+
+@pytest.mark.parametrize(
+    "fullpaths, branch_type, expected_fullpaths, error_message",
+    [
+        # Should filter down to only vk83, but no error is raised for allowed locations
+        (
+            [
+                f"{MODEL_CONFIG_INPUTS_LOCATION}/inputs/JRA-55/RYF/v1-4/data/RYF.vas.1990_1991.nc",
+                f"{PUBLISH_DATA_LOCATION[0]}/fake/file.txt",
+                f"{PUBLISH_DATA_LOCATION[1]}/fake/file2.txt",
+                f"{MODEL_CONFIG_INPUTS_PRERELEASE}/fake/file3.txt",
+            ],
+            "dev",
+            [
+                f"{MODEL_CONFIG_INPUTS_LOCATION}/inputs/JRA-55/RYF/v1-4/data/RYF.vas.1990_1991.nc"
+            ],
+            None,
+        ),
+        # Should raise an error for a non-published project location
+        (
+            ["/g/data/i101/fake/file.txt"],
+            "release",
+            [],
+            "is not in vk83 or a published data project location.",
+        ),
+        # Should raise an error for a release branch using prerelease inputs
+        (
+            [f"{MODEL_CONFIG_INPUTS_PRERELEASE}/fake/file.txt"],
+            "release",
+            [],
+            "is in prerelease location, which is not allowed for release branches.",
+        ),
+    ],
+)
+def test_check_allowed_config_location(
+    fullpaths, branch_type, expected_fullpaths, error_message
+):
+    """Test that the check_allowed_config_location function raise errors
+    if the configuration is not in an allowed location, or a release branch using prerelease inputs.
+    """
+    if error_message:
+        with pytest.raises(
+            RuntimeError, match=f"Input file {fullpaths[0]} {error_message}"
+        ):
+            check_allowed_config_location(fullpaths, branch_type)
+    else:
+        filter_fps = check_allowed_config_location(fullpaths, branch_type)
+        assert filter_fps == expected_fullpaths

--- a/tests/config_tests/qa/test_test_config.py
+++ b/tests/config_tests/qa/test_test_config.py
@@ -198,9 +198,10 @@ def test_fetch_input_md5_hashes_from_repo():
         return response
 
     with patch("requests.get", side_effect=mock_requests_get):
-        assert expected_hashes_from_repo == fetch_input_md5_hashes_from_repo(
-            expected_fullpaths
-        )
+        fetch_result = fetch_input_md5_hashes_from_repo(expected_fullpaths)
+        assert expected_hashes_from_repo == {
+            fullpath: info["md5hash"] for fullpath, info in fetch_result.items()
+        }
 
 
 def test_fetch_input_md5_hashes_from_repo_invalid():
@@ -264,7 +265,7 @@ def test_compare_input_md5_hashes():
             ["/g/data/i101/fake/file.txt"],
             "release",
             [],
-            "is not in vk83 or a published data project location.",
+            "is not in vk83 or a published data project location:",
         ),
         # Should raise an error for a release branch using prerelease inputs
         (
@@ -283,7 +284,7 @@ def test_check_allowed_config_location(
     """
     if error_message:
         with pytest.raises(
-            RuntimeError, match=f"Input file {fullpaths[0]} {error_message}"
+            AssertionError, match=f"Input file {fullpaths[0]} {error_message}"
         ):
             check_allowed_config_location(fullpaths, branch_type)
     else:

--- a/tests/resources/example_control_dir/config.yaml
+++ b/tests/resources/example_control_dir/config.yaml
@@ -1,0 +1,58 @@
+# Example payu configuration for ACCESS-OM2
+# This is a minimal example demonstrating the typical structure of a config.yaml file
+
+# PBS job submission settings
+queue: normal
+ncpus: 240
+jobfs: 10GB
+mem: 960GB
+
+walltime: 02:00:00
+jobname: example_1deg_jra55do_ryf
+
+# Model configuration
+name: common
+model: access-om2
+input:
+    - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_conserve2nd.nc
+  
+submodels:
+  - name: atmosphere
+    model: yatm
+    exe: yatm.exe
+    input: 
+      - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc
+      - /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data
+    ncpus: 1
+
+  - name: ocean
+    model: mom
+    exe: mom5_access_om
+    input:
+      - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/vertical/global.1deg/2020.10.22/ocean_vgrid.nc
+      - /g/data/vk83/experiments/inputs/access-om2/ocean/processor_masks/global.1deg/216.16x15/2020.05.30/ocean_mask_table
+    ncpus: 216
+
+  - name: ice
+    model: cice5
+    exe: cice_auscom_360x300_15x300.exe
+    input:
+      - /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.1deg/2024.04.17/grid.nc
+      - /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.1deg/2024.04.17/kmt.nc
+    ncpus: 24
+
+# Misc
+runlog: true
+stacksize: unlimited
+restart_freq: 5YS
+
+# Modules for loading model executables
+modules:
+  use:
+      - /g/data/vk83/modules
+  load:
+      - access-om2/2026.05.000
+      - model-tools/fre-nctools/2024.05-1
+
+# Minimum payu version requirement
+payu_minimum_version: 1.1.6

--- a/tests/resources/example_control_dir/manifests/input.yaml
+++ b/tests/resources/example_control_dir/manifests/input.yaml
@@ -1,0 +1,95 @@
+format: yamanifest
+version: 1.0
+---
+work/INPUT/JRA55_MOM1_conserve2nd.nc:
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_conserve2nd.nc
+  hashes:
+    binhash: 3ba86d1ae2c7641a29dce1179c55ad64
+    md5: 00be8ec0f1126055b65dc68178ce4eb5
+work/atmosphere/INPUT/rmp_jrar_to_cict_CONSERV.nc:
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc
+  hashes:
+    binhash: 1408c9a906c2c24a5a4cbdd47cd41670
+    md5: 10f0b5ea6b8102a03ad1140e5163a0f7
+work/ocean/INPUT/ocean_vgrid.nc:
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/grids/vertical/global.1deg/2020.10.22/ocean_vgrid.nc
+  hashes:
+    binhash: 4fd591112647a35b9450058070ce92ad
+    md5: 339ff716e3019a86fc861498e674250a
+work/ocean/INPUT/ocean_mask_table:
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/processor_masks/global.1deg/216.16x15/2020.05.30/ocean_mask_table
+  hashes:
+    binhash: f92a6c9cd60eb7ecae2c822031fc6dbe
+    md5: 2203b38758fb2b56a145ef16b7872af9
+work/ice/RESTART/grid.nc:
+  copy: true
+  fullpath: /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.1deg/2024.04.17/grid.nc
+  hashes:
+    binhash: 588f0b40bf750559434e425e7d039bca
+    md5: 7dd9ee5bce7f2eaeb75355684ddba599
+work/ice/RESTART/kmt.nc:
+  copy: true
+  fullpath: /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.1deg/2024.04.17/kmt.nc
+  hashes:
+    binhash: 2b659d429cbf9e12701709ff0185405f
+    md5: 9609d3db04f58cba200d7186dfe68ebd
+work/atmosphere/INPUT/RYF.friver.1990_1991.nc:
+  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.friver.1990_1991.nc
+  hashes:
+    binhash: df5b6715e020f563acb65673571a565f
+    md5: fa3a55aeb6706a1b422d096f61a772c1
+work/atmosphere/INPUT/RYF.huss.1990_1991.nc:
+  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.huss.1990_1991.nc
+  hashes:
+    binhash: 71d6099511ebc8b43f9b86b325ecf3af
+    md5: 6032d514fdfdd2b6a84bdef0a4ac3afe
+work/atmosphere/INPUT/RYF.licalvf.1990_1991.nc:
+  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.licalvf.1990_1991.nc
+  hashes:
+    binhash: f219ce98f3fcbe6f8ec517740f01aee1
+    md5: 6f927702cbc023cc20d3ddd69695f0a0
+work/atmosphere/INPUT/RYF.prra.1990_1991.nc:
+  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.prra.1990_1991.nc
+  hashes:
+    binhash: 2754bd49fff02bf5330a086310f1c296
+    md5: ac199086106ec4e41506e6082bccb109
+work/atmosphere/INPUT/RYF.prsn.1990_1991.nc:
+  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.prsn.1990_1991.nc
+  hashes:
+    binhash: 154a15cde4940309ac5e6fef0d7faba4
+    md5: cd076c877c2c5df61615e04d71ed00e0
+work/atmosphere/INPUT/RYF.psl.1990_1991.nc:
+  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.psl.1990_1991.nc
+  hashes:
+    binhash: 559b1e3183475cfb94a7f013f4acf8ea
+    md5: 0dfd94a5c3234fd2016dfdd01e84a170
+work/atmosphere/INPUT/RYF.rhuss.1990_1991.nc:
+  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.rhuss.1990_1991.nc
+  hashes:
+    binhash: 1f70c237032f7368e6f2478d2a678c99
+    md5: 632519955305cb5c19e286b151439fb5
+work/atmosphere/INPUT/RYF.rlds.1990_1991.nc:
+  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.rlds.1990_1991.nc
+  hashes:
+    binhash: 9512836673a68507bed403ecd859ba38
+    md5: 0ea83e107ec883c3f39a12b60ff50d8e
+work/atmosphere/INPUT/RYF.rsds.1990_1991.nc:
+  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.rsds.1990_1991.nc
+  hashes:
+    binhash: 7ff7cd79ace33fefe2b9a91ea018ea14
+    md5: b74bf123f1e4557368a61732cf24f1c2
+work/atmosphere/INPUT/RYF.tas.1990_1991.nc:
+  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.tas.1990_1991.nc
+  hashes:
+    binhash: 8f3c6798cc92a1d0b6573eb44b2a4dd2
+    md5: 06689885f4f2f726b95a2818ab78a20d
+work/atmosphere/INPUT/RYF.uas.1990_1991.nc:
+  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.uas.1990_1991.nc
+  hashes:
+    binhash: 54ede2172bf85bc861bc64c296a03f8c
+    md5: 107bf9480f55597655d2d283b6f6b4ff
+work/atmosphere/INPUT/RYF.vas.1990_1991.nc:
+  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.vas.1990_1991.nc
+  hashes:
+    binhash: 17224eecb745b6ce72604b41201c1fe7
+    md5: 88dc8c70338bbc8f5efc48ed0009a99f

--- a/tests/resources/example_control_dir/manifests/input.yaml
+++ b/tests/resources/example_control_dir/manifests/input.yaml
@@ -93,3 +93,8 @@ work/atmosphere/INPUT/RYF.vas.1990_1991.nc:
   hashes:
     binhash: 17224eecb745b6ce72604b41201c1fe7
     md5: 88dc8c70338bbc8f5efc48ed0009a99f
+  work/fake/file.txt:
+    fullpath: /g/data/qv56/replicas/fake/file.txt
+    hashes:
+      binhash: I_make_this_up
+      md5: Also_I_make_this_up

--- a/tests/resources/expected_md5hash.py
+++ b/tests/resources/expected_md5hash.py
@@ -1,0 +1,97 @@
+"""Test expected output and expected data for test_test_config tests."""
+
+expected_fullpaths = [
+    # Top-level input
+    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_conserve2nd.nc",
+    # Atmosphere submodel input
+    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data",
+    # Ocean submodel input
+    "/g/data/vk83/configurations/inputs/access-om2/ocean/grids/vertical/global.1deg/2020.10.22/ocean_vgrid.nc",
+    "/g/data/vk83/configurations/inputs/access-om2/ocean/processor_masks/global.1deg/216.16x15/2020.05.30/ocean_mask_table",
+    # Ice submodel input
+    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/grid.nc",
+    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/kmt.nc",
+]
+
+expected_hashes_from_repo = {
+    # OM2 remapping_weights
+    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_conserve2nd.nc": 
+    "00be8ec0f1126055b65dc68178ce4eb5",
+    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc": 
+    "10f0b5ea6b8102a03ad1140e5163a0f7",
+    # JRA-55/RYF/v1-4/data directory
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.friver.1990_1991.nc":
+    "fa3a55aeb6706a1b422d096f61a772c1",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.huss.1990_1991.nc":
+    "6032d514fdfdd2b6a84bdef0a4ac3afe",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.licalvf.1990_1991.nc":
+    "6f927702cbc023cc20d3ddd69695f0a0",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prra.1990_1991.nc":
+    "ac199086106ec4e41506e6082bccb109",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prsn.1990_1991.nc":
+    "cd076c877c2c5df61615e04d71ed00e0",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.psl.1990_1991.nc":
+    "0dfd94a5c3234fd2016dfdd01e84a170",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rhuss.1990_1991.nc":
+    "632519955305cb5c19e286b151439fb5",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rlds.1990_1991.nc":
+    "0ea83e107ec883c3f39a12b60ff50d8e",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rsds.1990_1991.nc":
+    "b74bf123f1e4557368a61732cf24f1c2",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.tas.1990_1991.nc":
+    "06689885f4f2f726b95a2818ab78a20d",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.uas.1990_1991.nc":
+    "107bf9480f55597655d2d283b6f6b4ff",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.vas.1990_1991.nc":
+    "88dc8c70338bbc8f5efc48ed0009a99f",
+    # OM2 ocean
+    "/g/data/vk83/configurations/inputs/access-om2/ocean/grids/vertical/global.1deg/2020.10.22/ocean_vgrid.nc": 
+    "339ff716e3019a86fc861498e674250a",
+    "/g/data/vk83/configurations/inputs/access-om2/ocean/processor_masks/global.1deg/216.16x15/2020.05.30/ocean_mask_table": 
+    "2203b38758fb2b56a145ef16b7872af9",
+    # OM2 ice
+    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/grid.nc": 
+    "7dd9ee5bce7f2eaeb75355684ddba599",
+    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/kmt.nc": 
+    "9609d3db04f58cba200d7186dfe68ebd",
+}
+
+expected_local_hashes = {
+    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_conserve2nd.nc":
+    "00be8ec0f1126055b65dc68178ce4eb5",
+    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc":
+    "10f0b5ea6b8102a03ad1140e5163a0f7",
+    "/g/data/vk83/configurations/inputs/access-om2/ocean/grids/vertical/global.1deg/2020.10.22/ocean_vgrid.nc":
+    "339ff716e3019a86fc861498e674250a",
+    "/g/data/vk83/configurations/inputs/access-om2/ocean/processor_masks/global.1deg/216.16x15/2020.05.30/ocean_mask_table":
+    "2203b38758fb2b56a145ef16b7872af9",
+    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/grid.nc":
+    "7dd9ee5bce7f2eaeb75355684ddba599",
+    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/kmt.nc":
+    "9609d3db04f58cba200d7186dfe68ebd",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.friver.1990_1991.nc":
+    "fa3a55aeb6706a1b422d096f61a772c1",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.huss.1990_1991.nc":
+    "6032d514fdfdd2b6a84bdef0a4ac3afe",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.licalvf.1990_1991.nc":
+    "6f927702cbc023cc20d3ddd69695f0a0",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prra.1990_1991.nc":
+    "ac199086106ec4e41506e6082bccb109",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prsn.1990_1991.nc":
+    "cd076c877c2c5df61615e04d71ed00e0",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.psl.1990_1991.nc":
+    "0dfd94a5c3234fd2016dfdd01e84a170",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rhuss.1990_1991.nc":
+    "632519955305cb5c19e286b151439fb5",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rlds.1990_1991.nc":
+    "0ea83e107ec883c3f39a12b60ff50d8e",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rsds.1990_1991.nc":
+    "b74bf123f1e4557368a61732cf24f1c2",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.tas.1990_1991.nc":
+    "06689885f4f2f726b95a2818ab78a20d",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.uas.1990_1991.nc":
+    "107bf9480f55597655d2d283b6f6b4ff",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.vas.1990_1991.nc":
+    "88dc8c70338bbc8f5efc48ed0009a99f",
+}

--- a/tests/resources/expected_md5hash.py
+++ b/tests/resources/expected_md5hash.py
@@ -16,82 +16,46 @@ expected_fullpaths = [
 
 expected_hashes_from_repo = {
     # OM2 remapping_weights
-    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_conserve2nd.nc": 
-    "00be8ec0f1126055b65dc68178ce4eb5",
-    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc": 
-    "10f0b5ea6b8102a03ad1140e5163a0f7",
+    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_conserve2nd.nc": "00be8ec0f1126055b65dc68178ce4eb5",
+    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc": "10f0b5ea6b8102a03ad1140e5163a0f7",
     # JRA-55/RYF/v1-4/data directory
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.friver.1990_1991.nc":
-    "fa3a55aeb6706a1b422d096f61a772c1",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.huss.1990_1991.nc":
-    "6032d514fdfdd2b6a84bdef0a4ac3afe",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.licalvf.1990_1991.nc":
-    "6f927702cbc023cc20d3ddd69695f0a0",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prra.1990_1991.nc":
-    "ac199086106ec4e41506e6082bccb109",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prsn.1990_1991.nc":
-    "cd076c877c2c5df61615e04d71ed00e0",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.psl.1990_1991.nc":
-    "0dfd94a5c3234fd2016dfdd01e84a170",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rhuss.1990_1991.nc":
-    "632519955305cb5c19e286b151439fb5",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rlds.1990_1991.nc":
-    "0ea83e107ec883c3f39a12b60ff50d8e",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rsds.1990_1991.nc":
-    "b74bf123f1e4557368a61732cf24f1c2",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.tas.1990_1991.nc":
-    "06689885f4f2f726b95a2818ab78a20d",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.uas.1990_1991.nc":
-    "107bf9480f55597655d2d283b6f6b4ff",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.vas.1990_1991.nc":
-    "88dc8c70338bbc8f5efc48ed0009a99f",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.friver.1990_1991.nc": "fa3a55aeb6706a1b422d096f61a772c1",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.huss.1990_1991.nc": "6032d514fdfdd2b6a84bdef0a4ac3afe",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.licalvf.1990_1991.nc": "6f927702cbc023cc20d3ddd69695f0a0",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prra.1990_1991.nc": "ac199086106ec4e41506e6082bccb109",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prsn.1990_1991.nc": "cd076c877c2c5df61615e04d71ed00e0",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.psl.1990_1991.nc": "0dfd94a5c3234fd2016dfdd01e84a170",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rhuss.1990_1991.nc": "632519955305cb5c19e286b151439fb5",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rlds.1990_1991.nc": "0ea83e107ec883c3f39a12b60ff50d8e",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rsds.1990_1991.nc": "b74bf123f1e4557368a61732cf24f1c2",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.tas.1990_1991.nc": "06689885f4f2f726b95a2818ab78a20d",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.uas.1990_1991.nc": "107bf9480f55597655d2d283b6f6b4ff",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.vas.1990_1991.nc": "88dc8c70338bbc8f5efc48ed0009a99f",
     # OM2 ocean
-    "/g/data/vk83/configurations/inputs/access-om2/ocean/grids/vertical/global.1deg/2020.10.22/ocean_vgrid.nc": 
-    "339ff716e3019a86fc861498e674250a",
-    "/g/data/vk83/configurations/inputs/access-om2/ocean/processor_masks/global.1deg/216.16x15/2020.05.30/ocean_mask_table": 
-    "2203b38758fb2b56a145ef16b7872af9",
+    "/g/data/vk83/configurations/inputs/access-om2/ocean/grids/vertical/global.1deg/2020.10.22/ocean_vgrid.nc": "339ff716e3019a86fc861498e674250a",
+    "/g/data/vk83/configurations/inputs/access-om2/ocean/processor_masks/global.1deg/216.16x15/2020.05.30/ocean_mask_table": "2203b38758fb2b56a145ef16b7872af9",
     # OM2 ice
-    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/grid.nc": 
-    "7dd9ee5bce7f2eaeb75355684ddba599",
-    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/kmt.nc": 
-    "9609d3db04f58cba200d7186dfe68ebd",
+    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/grid.nc": "7dd9ee5bce7f2eaeb75355684ddba599",
+    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/kmt.nc": "9609d3db04f58cba200d7186dfe68ebd",
 }
 
 expected_local_hashes = {
-    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_conserve2nd.nc":
-    "00be8ec0f1126055b65dc68178ce4eb5",
-    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc":
-    "10f0b5ea6b8102a03ad1140e5163a0f7",
-    "/g/data/vk83/configurations/inputs/access-om2/ocean/grids/vertical/global.1deg/2020.10.22/ocean_vgrid.nc":
-    "339ff716e3019a86fc861498e674250a",
-    "/g/data/vk83/configurations/inputs/access-om2/ocean/processor_masks/global.1deg/216.16x15/2020.05.30/ocean_mask_table":
-    "2203b38758fb2b56a145ef16b7872af9",
-    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/grid.nc":
-    "7dd9ee5bce7f2eaeb75355684ddba599",
-    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/kmt.nc":
-    "9609d3db04f58cba200d7186dfe68ebd",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.friver.1990_1991.nc":
-    "fa3a55aeb6706a1b422d096f61a772c1",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.huss.1990_1991.nc":
-    "6032d514fdfdd2b6a84bdef0a4ac3afe",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.licalvf.1990_1991.nc":
-    "6f927702cbc023cc20d3ddd69695f0a0",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prra.1990_1991.nc":
-    "ac199086106ec4e41506e6082bccb109",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prsn.1990_1991.nc":
-    "cd076c877c2c5df61615e04d71ed00e0",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.psl.1990_1991.nc":
-    "0dfd94a5c3234fd2016dfdd01e84a170",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rhuss.1990_1991.nc":
-    "632519955305cb5c19e286b151439fb5",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rlds.1990_1991.nc":
-    "0ea83e107ec883c3f39a12b60ff50d8e",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rsds.1990_1991.nc":
-    "b74bf123f1e4557368a61732cf24f1c2",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.tas.1990_1991.nc":
-    "06689885f4f2f726b95a2818ab78a20d",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.uas.1990_1991.nc":
-    "107bf9480f55597655d2d283b6f6b4ff",
-    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.vas.1990_1991.nc":
-    "88dc8c70338bbc8f5efc48ed0009a99f",
+    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_conserve2nd.nc": "00be8ec0f1126055b65dc68178ce4eb5",
+    "/g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc": "10f0b5ea6b8102a03ad1140e5163a0f7",
+    "/g/data/vk83/configurations/inputs/access-om2/ocean/grids/vertical/global.1deg/2020.10.22/ocean_vgrid.nc": "339ff716e3019a86fc861498e674250a",
+    "/g/data/vk83/configurations/inputs/access-om2/ocean/processor_masks/global.1deg/216.16x15/2020.05.30/ocean_mask_table": "2203b38758fb2b56a145ef16b7872af9",
+    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/grid.nc": "7dd9ee5bce7f2eaeb75355684ddba599",
+    "/g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/kmt.nc": "9609d3db04f58cba200d7186dfe68ebd",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.friver.1990_1991.nc": "fa3a55aeb6706a1b422d096f61a772c1",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.huss.1990_1991.nc": "6032d514fdfdd2b6a84bdef0a4ac3afe",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.licalvf.1990_1991.nc": "6f927702cbc023cc20d3ddd69695f0a0",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prra.1990_1991.nc": "ac199086106ec4e41506e6082bccb109",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prsn.1990_1991.nc": "cd076c877c2c5df61615e04d71ed00e0",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.psl.1990_1991.nc": "0dfd94a5c3234fd2016dfdd01e84a170",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rhuss.1990_1991.nc": "632519955305cb5c19e286b151439fb5",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rlds.1990_1991.nc": "0ea83e107ec883c3f39a12b60ff50d8e",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rsds.1990_1991.nc": "b74bf123f1e4557368a61732cf24f1c2",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.tas.1990_1991.nc": "06689885f4f2f726b95a2818ab78a20d",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.uas.1990_1991.nc": "107bf9480f55597655d2d283b6f6b4ff",
+    "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.vas.1990_1991.nc": "88dc8c70338bbc8f5efc48ed0009a99f",
 }

--- a/tests/resources/expected_md5hash.py
+++ b/tests/resources/expected_md5hash.py
@@ -59,3 +59,112 @@ expected_local_hashes = {
     "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.uas.1990_1991.nc": "107bf9480f55597655d2d283b6f6b4ff",
     "/g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.vas.1990_1991.nc": "88dc8c70338bbc8f5efc48ed0009a99f",
 }
+
+# Mock requests.get responses for manifest files from model-config-inputs, mapping URLs to their expected content
+mock_input_response = {
+    "https://raw.githubusercontent.com/ACCESS-NRI/model-config-inputs/main/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/.manifest.yaml": """format: yamanifest
+version: 1.0
+---
+JRA55_MOM1_conserve2nd.nc:
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_conserve2nd.nc
+  hashes:
+    binhash: 3ba86d1ae2c7641a29dce1179c55ad64
+    md5: 00be8ec0f1126055b65dc68178ce4eb5
+rmp_jrar_to_cict_CONSERV.nc:
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc
+  hashes:
+    binhash: 1408c9a906c2c24a5a4cbdd47cd41670
+    md5: 10f0b5ea6b8102a03ad1140e5163a0f7""",
+    "https://raw.githubusercontent.com/ACCESS-NRI/model-config-inputs/main/JRA-55/RYF/v1-4/data/.manifest.yaml": """format: yamanifest
+version: 1.0
+---
+RYF.friver.1990_1991.nc:
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.friver.1990_1991.nc
+  hashes:
+    binhash: abba207de30541a83d25e24b424cfa87
+    md5: fa3a55aeb6706a1b422d096f61a772c1
+RYF.huss.1990_1991.nc:
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.huss.1990_1991.nc
+  hashes:
+    binhash: 1d67d219c6f161051dec204a1842a968
+    md5: 6032d514fdfdd2b6a84bdef0a4ac3afe
+RYF.licalvf.1990_1991.nc:
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.licalvf.1990_1991.nc
+  hashes:
+    binhash: 834da0a081e904fdbc892255d1954062
+    md5: 6f927702cbc023cc20d3ddd69695f0a0
+RYF.prra.1990_1991.nc:
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prra.1990_1991.nc
+  hashes:
+    binhash: 7bc006b83a9891d4f9ef39f4d94ffb05
+    md5: ac199086106ec4e41506e6082bccb109
+RYF.prsn.1990_1991.nc:
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prsn.1990_1991.nc
+  hashes:
+    binhash: a57a154152a830ad1ca820ca9487d5ac
+    md5: cd076c877c2c5df61615e04d71ed00e0
+RYF.psl.1990_1991.nc:
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.psl.1990_1991.nc
+  hashes:
+    binhash: 420c371361bb677eb87c01255c6e62b3
+    md5: 0dfd94a5c3234fd2016dfdd01e84a170
+RYF.rhuss.1990_1991.nc:
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rhuss.1990_1991.nc
+  hashes:
+    binhash: fe4460b8d68f94df26adc52fb56a0d6a
+    md5: 632519955305cb5c19e286b151439fb5
+RYF.rlds.1990_1991.nc:
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rlds.1990_1991.nc
+  hashes:
+    binhash: 07a7fb6f9d2a3aee4081034f0cfc305a
+    md5: 0ea83e107ec883c3f39a12b60ff50d8e
+RYF.rsds.1990_1991.nc:
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rsds.1990_1991.nc
+  hashes:
+    binhash: 2d6c41b66024e460fcfe0a1668bfe151
+    md5: b74bf123f1e4557368a61732cf24f1c2
+RYF.tas.1990_1991.nc:
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.tas.1990_1991.nc
+  hashes:
+    binhash: 2a7a2f9903346123161b91ed8d5fab52
+    md5: 06689885f4f2f726b95a2818ab78a20d
+RYF.uas.1990_1991.nc:
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.uas.1990_1991.nc
+  hashes:
+    binhash: bfd4876aac0b31e51a18c7724c84d8b1
+    md5: 107bf9480f55597655d2d283b6f6b4ff
+RYF.vas.1990_1991.nc:
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.vas.1990_1991.nc
+  hashes:
+    binhash: d15ca562e37e82fb2d31657701f0a560
+    md5: 88dc8c70338bbc8f5efc48ed0009a99f""",
+    "https://raw.githubusercontent.com/ACCESS-NRI/model-config-inputs/main/access-om2/ocean/grids/vertical/global.1deg/2020.10.22/.manifest.yaml": """format: yamanifest
+version: 1.0
+---
+ocean_vgrid.nc:
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/grids/vertical/global.1deg/2020.10.22/ocean_vgrid.nc
+  hashes:
+    binhash: 4fd591112647a35b9450058070ce92ad
+    md5: 339ff716e3019a86fc861498e674250a""",
+    "https://raw.githubusercontent.com/ACCESS-NRI/model-config-inputs/main/access-om2/ocean/processor_masks/global.1deg/216.16x15/2020.05.30/.manifest.yaml": """format: yamanifest
+version: 1.0
+---
+ocean_mask_table:
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/processor_masks/global.1deg/216.16x15/2020.05.30/ocean_mask_table
+  hashes:
+    binhash: f92a6c9cd60eb7ecae2c822031fc6dbe
+    md5: 2203b38758fb2b56a145ef16b7872af9""",
+    "https://raw.githubusercontent.com/ACCESS-NRI/model-config-inputs/main/access-om2/ice/grids/global.1deg/2024.04.17/.manifest.yaml": """format: yamanifest
+version: 1.0
+---
+grid.nc:
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/grid.nc
+  hashes:
+    binhash: 8af00ee2b12207979097bf67708b38e5
+    md5: 7dd9ee5bce7f2eaeb75355684ddba599
+kmt.nc:
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ice/grids/global.1deg/2024.04.17/kmt.nc
+  hashes:
+    binhash: 5b1a8f815221fe504a70e7b7183ea995
+    md5: 9609d3db04f58cba200d7186dfe68ebd""",
+}


### PR DESCRIPTION
This PR checks whether the md5 hash in manifests/input.yaml matches those in model-config-inputs [repository](https://github.com/ACCESS-NRI/model-config-inputs/tree/main).

Ref #9  and [comment](https://github.com/ACCESS-NRI/model-config-tests/issues/9#issuecomment-2629627879).