### PR TITLE
Support 'Job ID:' prefix and no prefix.

### DIFF
--- a/src/model_config_tests/exp_test_helper.py
+++ b/src/model_config_tests/exp_test_helper.py
@@ -541,8 +541,8 @@ def parse_pbs_submitted_jobs(stdout: str) -> Optional[str]:
         Any submitted payu run ID. If a subsequent run job was
         not submitted, the id will be None.
     """
-    # The "Submitted job:" is optional
-    run_pattern = r"^(?:Submitted job: )?qsub.*/bin/payu-run$"
+    # The "Submitted command:" is optional
+    run_pattern = r"^(?:Submitted command: )?qsub.*/bin/payu-run$"
     run_submitted = re.search(run_pattern, stdout, re.MULTILINE) is not None
 
     job_ids = parse_gadi_pbs_ids(stdout)

--- a/src/model_config_tests/exp_test_helper.py
+++ b/src/model_config_tests/exp_test_helper.py
@@ -493,8 +493,8 @@ def parse_gadi_pbs_ids(stdout: str) -> list[str]:
     list[str]
         A list of jobs IDs printed out to a line
     """
-    # Define the regex pattern, e.g. 137776067.gadi-pbs
-    pattern = r"^(\d+\.gadi-pbs)$"
+    # Define the regex pattern, e.g. 137776067.gadi-pbs. The "Job ID:" prefix is optional
+    pattern = r"^(?:Job ID: )?(\d+\.gadi-pbs)$"
 
     # Find all matches in the text
     matches = re.findall(pattern, stdout, re.MULTILINE)
@@ -541,7 +541,8 @@ def parse_pbs_submitted_jobs(stdout: str) -> Optional[str]:
         Any submitted payu run ID. If a subsequent run job was
         not submitted, the id will be None.
     """
-    run_pattern = r"^qsub.*/bin/payu-run$"
+    # The "Submitted job:" is optional
+    run_pattern = r"^(?:Submitted job: )?qsub.*/bin/payu-run$"
     run_submitted = re.search(run_pattern, stdout, re.MULTILINE) is not None
 
     job_ids = parse_gadi_pbs_ids(stdout)

--- a/tests/resources/experiment-logs/pre-industrial-hpc.o138768371
+++ b/tests/resources/experiment-logs/pre-industrial-hpc.o138768371
@@ -18,12 +18,10 @@ Loading input manifest: manifests/input.yaml
 Loading restart manifest: manifests/restart.yaml
 Loading exe manifest: manifests/exe.yaml
 payu: Found modules in /opt/Modules/v4.3.0
-Job ID: 138776068.gadi-pbs
 Loading input manifest: manifests/input.yaml
 Loading restart manifest: manifests/restart.yaml
 Loading exe manifest: manifests/exe.yaml
 payu: Found modules in /opt/Modules/v4.3.0
-qsub -q normal -P testProject -l walltime=9000 -l ncpus=384 -l mem=1536GB -l jobfs=1500MB -N pre-industrial -l wd -j n -v PAYU_PATH=/g/data/vk83/prerelease/apps/base_conda/envs/payu-dev-20250220T210827Z-39e4b9b/bin,PAYU_CURRENT_RUN=1,PAYU_N_RUNS=1,MODULESHOME=/opt/Modules/v4.3.0,MODULES_CMD=/opt/Modules/v4.3.0/libexec/modulecmd.tcl,MODULEPATH=/g/data/vk83/modules:/g/data/vk83/prerelease/modules:/etc/scl/modulefiles:/opt/Modules/modulefiles:/opt/Modules/v4.3.0/modulefiles:/apps/Modules/modulefiles -W umask=027 -l storage=gdata/vk83 -- /g/data/vk83/prerelease/./apps/conda_scripts/payu-dev-20250220T210827Z-39e4b9b.d/bin/python /g/data/vk83/prerelease/apps/base_conda/envs/payu-dev-20250220T210827Z-39e4b9b/bin/payu-run
 mod cice4/2024.05.21
 mod mom5/access-esm1.5_2024.08.23
 mod um7/2024.07.03
@@ -53,6 +51,9 @@ git add manifests/exe.yaml
 git commit -am "2025-03-27 17:37:04: Run 0"
 git commit --no-gpg-sign -am "2025-03-27 17:37:04: Run 0"
 mpirun  -wdir /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/atmosphere -np 192  /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/atmosphere/um_hg3.exe : -wdir /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/ocean -np 180  /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/ocean/fms_ACCESS-CM.x : -wdir /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/ice -np 12  /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/ice/cice_access_360x300_12x1_12p.exe
+------ Job submitted ------
+Submitted command: qsub -q normal -P testProject -l walltime=9000 -l ncpus=384 -l mem=1536GB -l jobfs=1500MB -N pre-industrial -l wd -j n -v PAYU_PATH=/g/data/vk83/prerelease/apps/base_conda/envs/payu-dev-20250220T210827Z-39e4b9b/bin,PAYU_CURRENT_RUN=1,PAYU_N_RUNS=1,MODULESHOME=/opt/Modules/v4.3.0,MODULES_CMD=/opt/Modules/v4.3.0/libexec/modulecmd.tcl,MODULEPATH=/g/data/vk83/modules:/g/data/vk83/prerelease/modules:/etc/scl/modulefiles:/opt/Modules/modulefiles:/opt/Modules/v4.3.0/modulefiles:/apps/Modules/modulefiles -W umask=027 -l storage=gdata/vk83 -- /g/data/vk83/prerelease/./apps/conda_scripts/payu-dev-20250220T210827Z-39e4b9b.d/bin/python /g/data/vk83/prerelease/apps/base_conda/envs/payu-dev-20250220T210827Z-39e4b9b/bin/payu-run
+Job ID: 138776068.gadi-pbs
 
 ======================================================================================
                   Resource Usage on 2025-03-27 17:38:02:

--- a/tests/resources/experiment-logs/pre-industrial-hpc.o138768371
+++ b/tests/resources/experiment-logs/pre-industrial-hpc.o138768371
@@ -1,9 +1,5 @@
-laboratory path:  /scratch/testProject/testUser/access-esm
-binary path:  /scratch/testProject/testUser/access-esm/bin
-input path:  /scratch/testProject/testUser/access-esm/input
-work path:  /scratch/testProject/testUser/access-esm/work
-archive path:  /scratch/testProject/testUser/access-esm/archive
-Found experiment archive: /scratch/testProject/testUser/access-esm/archive/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07
+archive path:  /scratch/tm70/qc4677/tmp/test-model-repro/lab/archive
+Experiment name is configured in config.yaml:  new_expt-exp_1d_runtime
 nruns: 2 nruns_per_submit: 1 subrun: 1
 payu: Found modules in /opt/Modules/v4.3.0
 Loading input manifest: manifests/input.yaml
@@ -12,58 +8,42 @@ Loading exe manifest: manifests/exe.yaml
 Setting up atmosphere
 Setting up ocean
 Setting up ice
-Setting up coupler
+Setting up access-om2
 Checking exe, input and restart manifests
+Writing manifests/restart.yaml
+mod oasis3-mct/2025.03.001-umkbobq
+mod libaccessom2/2026.02.000-ufu526k
+mod cice5/2026.01.000-ejgeocv
+mod mom5/2026.02.000-vxwlyl7
+mod access-om2/2026.05.000
+mod model-tools/fre-nctools/2024.05-1
+mpirun --mca io ompio --mca io_ompio_num_aggregators 1 -wdir /scratch/tm70/qc4677/tmp/test-model-repro/lab/work/new_expt-exp_1d_runtime/atmosphere -np 1  /scratch/tm70/qc4677/tmp/test-model-repro/lab/work/new_expt-exp_1d_runtime/atmosphere/yatm.exe : -wdir /scratch/tm70/qc4677/tmp/test-model-repro/lab/work/new_expt-exp_1d_runtime/ocean -np 216  /scratch/tm70/qc4677/tmp/test-model-repro/lab/work/new_expt-exp_1d_runtime/ocean/mom5_access_om : -wdir /scratch/tm70/qc4677/tmp/test-model-repro/lab/work/new_expt-exp_1d_runtime/ice -np 24  /scratch/tm70/qc4677/tmp/test-model-repro/lab/work/new_expt-exp_1d_runtime/ice/cice_auscom_360x300_15x300.exe
+rm -f resubmit.count
+payu: Found modules in /opt/Modules/v4.3.0
+laboratory path:  /scratch/tm70/qc4677/tmp/test-model-repro/lab
+binary path:  /scratch/tm70/qc4677/tmp/test-model-repro/lab/bin
+input path:  /scratch/tm70/qc4677/tmp/test-model-repro/lab/input
+work path:  /scratch/tm70/qc4677/tmp/test-model-repro/lab/work
+archive path:  /scratch/tm70/qc4677/tmp/test-model-repro/lab/archive
+Experiment name is configured in config.yaml:  new_expt-exp_1d_runtime
+payu: warning: Job request includes 47 unused CPUs.
+payu: warning: CPU request increased from 241 to 288
 Loading input manifest: manifests/input.yaml
 Loading restart manifest: manifests/restart.yaml
 Loading exe manifest: manifests/exe.yaml
 payu: Found modules in /opt/Modules/v4.3.0
-Loading input manifest: manifests/input.yaml
-Loading restart manifest: manifests/restart.yaml
-Loading exe manifest: manifests/exe.yaml
-payu: Found modules in /opt/Modules/v4.3.0
-mod cice4/2024.05.21
-mod mom5/access-esm1.5_2024.08.23
-mod um7/2024.07.03
-mod access-esm1p5/2024.05.1
-git add /home/189/testUser/test-payu/access-esm1.5-configs/config.yaml
-git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/errflag
-git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/hnlist
-git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/ihist
-git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/namelists
-git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/prefix.PRESM_A
-git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/STASHC
-git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/UAFILES_A
-git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/UAFLDS_A
-git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/cable.nml
-git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/um_env.yaml
-git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/input_atm.nml
-git add /home/189/testUser/test-payu/access-esm1.5-configs/ocean/data_table
-git add /home/189/testUser/test-payu/access-esm1.5-configs/ocean/diag_table
-git add /home/189/testUser/test-payu/access-esm1.5-configs/ocean/field_table
-git add /home/189/testUser/test-payu/access-esm1.5-configs/ocean/input.nml
-git add /home/189/testUser/test-payu/access-esm1.5-configs/ice/cice_in.nml
-git add /home/189/testUser/test-payu/access-esm1.5-configs/ice/input_ice.nml
-git add /home/189/testUser/test-payu/access-esm1.5-configs/coupler/namcouple
-git add manifests/input.yaml
-git add manifests/restart.yaml
-git add manifests/exe.yaml
-git commit -am "2025-03-27 17:37:04: Run 0"
-git commit --no-gpg-sign -am "2025-03-27 17:37:04: Run 0"
-mpirun  -wdir /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/atmosphere -np 192  /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/atmosphere/um_hg3.exe : -wdir /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/ocean -np 180  /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/ocean/fms_ACCESS-CM.x : -wdir /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/ice -np 12  /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/ice/cice_access_360x300_12x1_12p.exe
 ------ Job submitted ------
-Submitted command: qsub -q normal -P testProject -l walltime=9000 -l ncpus=384 -l mem=1536GB -l jobfs=1500MB -N pre-industrial -l wd -j n -v PAYU_PATH=/g/data/vk83/prerelease/apps/base_conda/envs/payu-dev-20250220T210827Z-39e4b9b/bin,PAYU_CURRENT_RUN=1,PAYU_N_RUNS=1,MODULESHOME=/opt/Modules/v4.3.0,MODULES_CMD=/opt/Modules/v4.3.0/libexec/modulecmd.tcl,MODULEPATH=/g/data/vk83/modules:/g/data/vk83/prerelease/modules:/etc/scl/modulefiles:/opt/Modules/modulefiles:/opt/Modules/v4.3.0/modulefiles:/apps/Modules/modulefiles -W umask=027 -l storage=gdata/vk83 -- /g/data/vk83/prerelease/./apps/conda_scripts/payu-dev-20250220T210827Z-39e4b9b.d/bin/python /g/data/vk83/prerelease/apps/base_conda/envs/payu-dev-20250220T210827Z-39e4b9b/bin/payu-run
-Job ID: 138776068.gadi-pbs
+Submitted command: qsub -P tm70 -l walltime=10800 -l ncpus=288 -l mem=1000GB -N 1deg_jra55_ryf -l wd -j n -W umask=027 -q normal -l storage=gdata/vk83+scratch/tm70 -v LD_LIBRARY_PATH=/usr/lib64,PAYU_PATH=/scratch/tm70/qc4677/model-config-tests/bin,PAYU_CURRENT_RUN=1,PAYU_N_RUNS=1,MODULESHOME=/opt/Modules/v4.3.0,MODULES_CMD=/opt/Modules/v4.3.0/libexec/modulecmd.tcl,MODULEPATH=/g/data/vk83/modules:/etc/scl/modulefiles:/opt/Modules/modulefiles:/opt/Modules/v4.3.0/modulefiles:/apps/Modules/modulefiles -- /scratch/tm70/qc4677/model-config-tests/bin/python3.11 /scratch/tm70/qc4677/model-config-tests/bin/payu-run
+Job ID: 175421114.gadi-pbs
 
 ======================================================================================
-                  Resource Usage on 2025-03-27 17:38:02:
-   Job Id:             137768371.gadi-pbs
-   Project:            testProject
+                  Resource Usage on 2026-08-05 12:34:50:
+   Job Id:             175420923.gadi-pbs
+   Project:            tm70
    Exit Status:        0
-   Service Units:      13.01
-   NCPUs Requested:    384                    NCPUs Used: 384             
-                                           CPU Time Used: 02:24:47        
-   Memory Requested:   1.5TB                 Memory Used: 151.26GB        
-   Walltime requested: 02:30:00            Walltime Used: 00:01:01        
-   JobFS requested:    1.46GB                 JobFS used: 0B              
+   Service Units:      5.92
+   NCPUs Requested:    288                 CPU Time Used: 00:36:52
+   Memory Requested:   1000.0GB              Memory Used: 71.94GB
+   Walltime Requested: 03:00:00            Walltime Used: 00:00:37
+   JobFS Requested:    600.0MB                JobFS Used: 0B
 ======================================================================================

--- a/tests/resources/experiment-logs/pre-industrial-hpc.o138768371
+++ b/tests/resources/experiment-logs/pre-industrial-hpc.o138768371
@@ -1,0 +1,68 @@
+laboratory path:  /scratch/testProject/testUser/access-esm
+binary path:  /scratch/testProject/testUser/access-esm/bin
+input path:  /scratch/testProject/testUser/access-esm/input
+work path:  /scratch/testProject/testUser/access-esm/work
+archive path:  /scratch/testProject/testUser/access-esm/archive
+Found experiment archive: /scratch/testProject/testUser/access-esm/archive/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07
+nruns: 2 nruns_per_submit: 1 subrun: 1
+payu: Found modules in /opt/Modules/v4.3.0
+Loading input manifest: manifests/input.yaml
+Loading restart manifest: manifests/restart.yaml
+Loading exe manifest: manifests/exe.yaml
+Setting up atmosphere
+Setting up ocean
+Setting up ice
+Setting up coupler
+Checking exe, input and restart manifests
+Loading input manifest: manifests/input.yaml
+Loading restart manifest: manifests/restart.yaml
+Loading exe manifest: manifests/exe.yaml
+payu: Found modules in /opt/Modules/v4.3.0
+Job ID: 138776068.gadi-pbs
+Loading input manifest: manifests/input.yaml
+Loading restart manifest: manifests/restart.yaml
+Loading exe manifest: manifests/exe.yaml
+payu: Found modules in /opt/Modules/v4.3.0
+qsub -q normal -P testProject -l walltime=9000 -l ncpus=384 -l mem=1536GB -l jobfs=1500MB -N pre-industrial -l wd -j n -v PAYU_PATH=/g/data/vk83/prerelease/apps/base_conda/envs/payu-dev-20250220T210827Z-39e4b9b/bin,PAYU_CURRENT_RUN=1,PAYU_N_RUNS=1,MODULESHOME=/opt/Modules/v4.3.0,MODULES_CMD=/opt/Modules/v4.3.0/libexec/modulecmd.tcl,MODULEPATH=/g/data/vk83/modules:/g/data/vk83/prerelease/modules:/etc/scl/modulefiles:/opt/Modules/modulefiles:/opt/Modules/v4.3.0/modulefiles:/apps/Modules/modulefiles -W umask=027 -l storage=gdata/vk83 -- /g/data/vk83/prerelease/./apps/conda_scripts/payu-dev-20250220T210827Z-39e4b9b.d/bin/python /g/data/vk83/prerelease/apps/base_conda/envs/payu-dev-20250220T210827Z-39e4b9b/bin/payu-run
+mod cice4/2024.05.21
+mod mom5/access-esm1.5_2024.08.23
+mod um7/2024.07.03
+mod access-esm1p5/2024.05.1
+git add /home/189/testUser/test-payu/access-esm1.5-configs/config.yaml
+git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/errflag
+git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/hnlist
+git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/ihist
+git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/namelists
+git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/prefix.PRESM_A
+git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/STASHC
+git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/UAFILES_A
+git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/UAFLDS_A
+git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/cable.nml
+git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/um_env.yaml
+git add /home/189/testUser/test-payu/access-esm1.5-configs/atmosphere/input_atm.nml
+git add /home/189/testUser/test-payu/access-esm1.5-configs/ocean/data_table
+git add /home/189/testUser/test-payu/access-esm1.5-configs/ocean/diag_table
+git add /home/189/testUser/test-payu/access-esm1.5-configs/ocean/field_table
+git add /home/189/testUser/test-payu/access-esm1.5-configs/ocean/input.nml
+git add /home/189/testUser/test-payu/access-esm1.5-configs/ice/cice_in.nml
+git add /home/189/testUser/test-payu/access-esm1.5-configs/ice/input_ice.nml
+git add /home/189/testUser/test-payu/access-esm1.5-configs/coupler/namcouple
+git add manifests/input.yaml
+git add manifests/restart.yaml
+git add manifests/exe.yaml
+git commit -am "2025-03-27 17:37:04: Run 0"
+git commit --no-gpg-sign -am "2025-03-27 17:37:04: Run 0"
+mpirun  -wdir /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/atmosphere -np 192  /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/atmosphere/um_hg3.exe : -wdir /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/ocean -np 180  /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/ocean/fms_ACCESS-CM.x : -wdir /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/ice -np 12  /scratch/testProject/testUser/access-esm/work/access-esm1.5-configs-release-preindustrial+concentrations-1d-69630b07/ice/cice_access_360x300_12x1_12p.exe
+
+======================================================================================
+                  Resource Usage on 2025-03-27 17:38:02:
+   Job Id:             137768371.gadi-pbs
+   Project:            testProject
+   Exit Status:        0
+   Service Units:      13.01
+   NCPUs Requested:    384                    NCPUs Used: 384             
+                                           CPU Time Used: 02:24:47        
+   Memory Requested:   1.5TB                 Memory Used: 151.26GB        
+   Walltime requested: 02:30:00            Walltime Used: 00:01:01        
+   JobFS requested:    1.46GB                 JobFS used: 0B              
+======================================================================================

--- a/tests/test_exp_test_helper.py
+++ b/tests/test_exp_test_helper.py
@@ -252,7 +252,7 @@ def test_parse_run_id_parsing_error(example_stdout):
     [
         ("pre-industrial.o137768371", ["137776068.gadi-pbs"]),
         ("pre-industrial.o137776068", []),
-        ("pre-industrial-hpc.o138768371", ["138776068.gadi-pbs"]),
+        ("pre-industrial-hpc.o138768371", ["175421114.gadi-pbs"]),
     ],
 )
 def test_parse_gadi_pbs_ids(stdout_filename, expected_ids):

--- a/tests/test_exp_test_helper.py
+++ b/tests/test_exp_test_helper.py
@@ -225,6 +225,7 @@ def test_experiment_submit_payu_run_error(mock_run, exp):
     [
         "137650670.gadi-pbs\ngadi-pbs ID output is first line\n",
         "gadi-pbs ID\nIs the last line\n137650670.gadi-pbs\n",
+        "Some output\nJob ID: 137650670.gadi-pbs\nMore output\n",
     ],
 )
 def test_parse_run_id(example_stdout):
@@ -237,6 +238,7 @@ def test_parse_run_id(example_stdout):
     [
         "No job ID here\nJust some output\n",
         "Multiple IDs\n12345.gadi-pbs\n67890.gadi-pbs\n",
+        "Multiple IDs with Job ID prefix\nJob ID: 12345.gadi-pbs\nJob ID: 67890.gadi-pbs\n",
     ],
 )
 def test_parse_run_id_parsing_error(example_stdout):
@@ -250,6 +252,7 @@ def test_parse_run_id_parsing_error(example_stdout):
     [
         ("pre-industrial.o137768371", ["137776068.gadi-pbs"]),
         ("pre-industrial.o137776068", []),
+        ("pre-industrial-hpc.o138768371", ["138776068.gadi-pbs"]),
     ],
 )
 def test_parse_gadi_pbs_ids(stdout_filename, expected_ids):


### PR DESCRIPTION
This PR updates the `parse_gadi_pbs_ids` and `parse_pbs_submitted_jobs` so model-config-tests can parse  job id from both formats:
```
--------- Job submitted ---------
Submission command: qsub xxxxx
Job ID: 1700000.gadi-pbs
```
```
17000000.gadi-pbs
```
Closes #237 